### PR TITLE
fix: corregir desfase de fecha en fci (issue #13)

### DIFF
--- a/all-in-one.js
+++ b/all-in-one.js
@@ -1,5 +1,5 @@
 // Archivo consolidado generado automáticamente
-// Fecha de generación: 2025-05-21T23:55:11.026Z
+// Fecha de generación: 2026-04-16T17:38:30.117Z
 
 // Namespace para constantes compartidas
 var CONSTANTS = {};
@@ -986,6 +986,61 @@ function dolar_historico_todos(fecha) {
  * @customfunction
  */
 function fci(tipoFondo, nombreFondo, fecha, campo) {
+  function esFechaValida(year, month, day) {
+    if (month < 1 || month > 12 || day < 1 || day > 31) {
+      return false;
+    }
+    var fechaUTC = new Date(Date.UTC(year, month - 1, day));
+    var fechaLocal = new Date(year, month - 1, day);
+    return fechaUTC.getUTCFullYear() === year &&
+           (fechaUTC.getUTCMonth() + 1) === month &&
+           fechaUTC.getUTCDate() === day &&
+           fechaLocal.getFullYear() === year &&
+           (fechaLocal.getMonth() + 1) === month &&
+           fechaLocal.getDate() === day;
+  }
+
+  function obtenerComponentesFecha(fechaInput) {
+    var year;
+    var month;
+    var day;
+
+    if (fechaInput instanceof Date) {
+      if (isNaN(fechaInput.getTime())) {
+        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+      }
+      year = fechaInput.getFullYear();
+      month = fechaInput.getMonth() + 1;
+      day = fechaInput.getDate();
+    } else {
+      var fechaStr = fechaInput.toString().trim();
+      var matchISO = fechaStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      var matchUS = fechaStr.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+
+      if (matchISO) {
+        year = parseInt(matchISO[1], 10);
+        month = parseInt(matchISO[2], 10);
+        day = parseInt(matchISO[3], 10);
+      } else if (matchUS) {
+        month = parseInt(matchUS[1], 10);
+        day = parseInt(matchUS[2], 10);
+        year = parseInt(matchUS[3], 10);
+      } else {
+        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+      }
+    }
+
+    if (!esFechaValida(year, month, day)) {
+      throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+    }
+
+    return {
+      year: year.toString(),
+      month: month.toString().padStart(2, '0'),
+      day: day.toString().padStart(2, '0')
+    };
+  }
+
   // Normalizo entradas
   var tipo = tipoFondo ? tipoFondo.toString().toLowerCase().trim() : '';
   var nombre = nombreFondo ? nombreFondo.toString().trim() : '';
@@ -1020,35 +1075,12 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
   // Construir URL según si se proporciona fecha o no
   var url;
   if (fecha) {
-    // Formatear la fecha a YYYY/MM/DD si viene en otro formato
-    var fechaObj;
     try {
-      if (fecha instanceof Date) {
-        fechaObj = fecha;
-      } else {
-        // Convertir de formato MM/DD/YYYY a YYYY-MM-DD si es necesario
-        if (fecha.indexOf('/') !== -1) {
-          var partes = fecha.split('/');
-          if (partes.length === 3) {
-            fecha = partes[2] + '-' + partes[0] + '-' + partes[1];
-          }
-        }
-        fechaObj = new Date(fecha);
-        
-        // Verificar si la fecha es válida
-        if (isNaN(fechaObj.getTime())) {
-          throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-        }
-      }
+      var componentesFecha = obtenerComponentesFecha(fecha);
+      url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/' + componentesFecha.year + '/' + componentesFecha.month + '/' + componentesFecha.day + '/';
     } catch (e) {
       throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
     }
-    
-    // Formatear a YYYY/MM/DD para la URL
-    var year = fechaObj.getFullYear();
-    var month = (fechaObj.getMonth() + 1).toString().padStart(2, '0');
-    var day = fechaObj.getDate().toString().padStart(2, '0');
-    url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/' + year + '/' + month + '/' + day + '/';
   } else {
     url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/ultimo';
   }
@@ -1176,6 +1208,7 @@ function fciLista() {
   
   return todosLosFondos;
 } 
+
 // ================ inflacion.js ================
 /**
  * Obtiene los índices de inflación de Argentina.

--- a/src/fci.js
+++ b/src/fci.js
@@ -9,6 +9,61 @@
  * @customfunction
  */
 function fci(tipoFondo, nombreFondo, fecha, campo) {
+  function esFechaValida(year, month, day) {
+    if (month < 1 || month > 12 || day < 1 || day > 31) {
+      return false;
+    }
+    var fechaUTC = new Date(Date.UTC(year, month - 1, day));
+    var fechaLocal = new Date(year, month - 1, day);
+    return fechaUTC.getUTCFullYear() === year &&
+           (fechaUTC.getUTCMonth() + 1) === month &&
+           fechaUTC.getUTCDate() === day &&
+           fechaLocal.getFullYear() === year &&
+           (fechaLocal.getMonth() + 1) === month &&
+           fechaLocal.getDate() === day;
+  }
+
+  function obtenerComponentesFecha(fechaInput) {
+    var year;
+    var month;
+    var day;
+
+    if (fechaInput instanceof Date) {
+      if (isNaN(fechaInput.getTime())) {
+        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+      }
+      year = fechaInput.getFullYear();
+      month = fechaInput.getMonth() + 1;
+      day = fechaInput.getDate();
+    } else {
+      var fechaStr = fechaInput.toString().trim();
+      var matchISO = fechaStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      var matchUS = fechaStr.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+
+      if (matchISO) {
+        year = parseInt(matchISO[1], 10);
+        month = parseInt(matchISO[2], 10);
+        day = parseInt(matchISO[3], 10);
+      } else if (matchUS) {
+        month = parseInt(matchUS[1], 10);
+        day = parseInt(matchUS[2], 10);
+        year = parseInt(matchUS[3], 10);
+      } else {
+        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+      }
+    }
+
+    if (!esFechaValida(year, month, day)) {
+      throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+    }
+
+    return {
+      year: year.toString(),
+      month: month.toString().padStart(2, '0'),
+      day: day.toString().padStart(2, '0')
+    };
+  }
+
   // Normalizo entradas
   var tipo = tipoFondo ? tipoFondo.toString().toLowerCase().trim() : '';
   var nombre = nombreFondo ? nombreFondo.toString().trim() : '';
@@ -43,35 +98,12 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
   // Construir URL según si se proporciona fecha o no
   var url;
   if (fecha) {
-    // Formatear la fecha a YYYY/MM/DD si viene en otro formato
-    var fechaObj;
     try {
-      if (fecha instanceof Date) {
-        fechaObj = fecha;
-      } else {
-        // Convertir de formato MM/DD/YYYY a YYYY-MM-DD si es necesario
-        if (fecha.indexOf('/') !== -1) {
-          var partes = fecha.split('/');
-          if (partes.length === 3) {
-            fecha = partes[2] + '-' + partes[0] + '-' + partes[1];
-          }
-        }
-        fechaObj = new Date(fecha);
-        
-        // Verificar si la fecha es válida
-        if (isNaN(fechaObj.getTime())) {
-          throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-        }
-      }
+      var componentesFecha = obtenerComponentesFecha(fecha);
+      url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/' + componentesFecha.year + '/' + componentesFecha.month + '/' + componentesFecha.day + '/';
     } catch (e) {
       throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
     }
-    
-    // Formatear a YYYY/MM/DD para la URL
-    var year = fechaObj.getFullYear();
-    var month = (fechaObj.getMonth() + 1).toString().padStart(2, '0');
-    var day = fechaObj.getDate().toString().padStart(2, '0');
-    url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/' + year + '/' + month + '/' + day + '/';
   } else {
     url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/ultimo';
   }

--- a/tests/fci.test.js
+++ b/tests/fci.test.js
@@ -1,0 +1,97 @@
+function createResponse(statusCode, body) {
+  return {
+    getResponseCode: () => statusCode,
+    getContentText: () => JSON.stringify(body),
+  };
+}
+
+describe("fci", () => {
+  let fci;
+  let fetchMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    fetchMock = jest.fn();
+
+    global.UrlFetchApp = {
+      fetch: fetchMock,
+    };
+    global.Utilities = {};
+    global.DriveApp = {};
+    global.Logger = { log: jest.fn() };
+
+    ({ fci } = require("./test-wrapper"));
+  });
+
+  afterEach(() => {
+    delete global.UrlFetchApp;
+    delete global.Utilities;
+    delete global.DriveApp;
+    delete global.Logger;
+  });
+
+  test("usa la fecha YYYY-MM-DD sin corrimiento por timezone", () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, [
+        {
+          fondo: "Cocos Rendimiento - Clase A",
+          vcp: 123.45,
+          ccp: 100,
+          patrimonio: 1000,
+        },
+      ])
+    );
+
+    const result = fci("rentaMixta", "Cocos Rendimiento - Clase A", "2026-04-13");
+
+    expect(result).toBe(123.45);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain("/rentaMixta/2026/04/13/");
+    expect(fetchMock.mock.calls[0][0]).not.toContain("/rentaMixta/2026/04/12/");
+  });
+
+  test("acepta MM/DD/YYYY y apunta al mismo endpoint normalizado", () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, [
+        {
+          fondo: "Cocos Rendimiento - Clase A",
+          vcp: 200,
+          ccp: 100,
+          patrimonio: 1000,
+        },
+      ])
+    );
+
+    const result = fci("rentaMixta", "Cocos Rendimiento - Clase A", "04/13/2026");
+
+    expect(result).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain("/rentaMixta/2026/04/13/");
+  });
+
+  test("rechaza fecha inválida y no consulta la API", () => {
+    expect(() =>
+      fci("rentaMixta", "Cocos Rendimiento - Clase A", "2026-13-40")
+    ).toThrow("Fecha inválida");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("sin fecha usa endpoint /ultimo", () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, [
+        {
+          fondo: "Cocos Rendimiento - Clase A",
+          vcp: 321,
+          ccp: 100,
+          patrimonio: 1000,
+        },
+      ])
+    );
+
+    const result = fci("rentaMixta", "Cocos Rendimiento - Clase A");
+
+    expect(result).toBe(321);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain("/rentaMixta/ultimo");
+  });
+});


### PR DESCRIPTION
## Summary
- corrige el parseo de fechas en `fci` para evitar corrimiento por timezone con `YYYY-MM-DD`
- mantiene soporte para `MM/DD/YYYY` y para `Date` nativo
- agrega validación estricta de fechas y normalización de componentes `YYYY/MM/DD`
- agrega tests de regresión para issue #13
- regenera `all-in-one.js`

## Testing
- npm test -- --runInBand tests/fci.test.js
- npm test -- --runInBand

Fixes #13
