### PR TITLE
feat: add retornoTotal FCI fund type

### DIFF
--- a/all-in-one.js
+++ b/all-in-one.js
@@ -1,5 +1,5 @@
 // Archivo consolidado generado automáticamente
-// Fecha de generación: 2026-04-16T17:38:30.117Z
+// Fecha de generación: 2026-04-21T21:30:56.419Z
 
 // Namespace para constantes compartidas
 var CONSTANTS = {};
@@ -978,7 +978,7 @@ function dolar_historico_todos(fecha) {
 /**
  * Obtiene información de Fondos Comunes de Inversión (FCI) de Argentina.
  *
- * @param {string} tipoFondo El tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta"
+ * @param {string} tipoFondo El tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta", "retornoTotal"
  * @param {string} nombreFondo El nombre del fondo a consultar (ej: "Balanz Money Market USD - Clase A")
  * @param {string} fecha [Opcional] Fecha en formato 'YYYY-MM-DD'. Si no se proporciona, devuelve la información más reciente.
  * @param {string} campo [Opcional] Campo a consultar: "vcp" (valor cuotaparte), "ccp" (cantidad cuotapartes), "patrimonio". Por defecto: "vcp".
@@ -1047,9 +1047,9 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
   var campoDatos = campo ? campo.toString().toLowerCase().trim() : 'vcp';
   
   // Validar tipo de fondo
-  var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta'];
+  var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta', 'retornototal'];
   if (!tiposPermitidos.includes(tipo.replace(/\s+/g, '').replace(/[óo]/, 'o'))) {
-    throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta.");
+    throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta, retornoTotal.");
   }
   
   // Convertir tipo a formato de API
@@ -1059,6 +1059,7 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     case 'rentavariable': tipoAPI = 'rentaVariable'; break;
     case 'rentafija': tipoAPI = 'rentaFija'; break;
     case 'rentamixta': tipoAPI = 'rentaMixta'; break;
+    case 'retornototal': tipoAPI = 'retornoTotal'; break;
   }
   
   // Validar el campo a consultar
@@ -1154,7 +1155,7 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
  */
 function fciLista() {
   // Tipos de fondos a consultar
-  var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta'];
+  var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta', 'retornoTotal'];
   
   // Matriz para almacenar todos los fondos
   var todosLosFondos = [['Nombre del Fondo', 'Tipo de Fondo', 'Valor Cuotaparte']];
@@ -1191,6 +1192,7 @@ function fciLista() {
             case 'rentaVariable': nombreFormateado = 'Renta Variable'; break;
             case 'rentaFija': nombreFormateado = 'Renta Fija'; break;
             case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
+            case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
           }
           
           todosLosFondos.push([

--- a/doc/FCI.md
+++ b/doc/FCI.md
@@ -13,7 +13,7 @@ En cualquier celda de la hoja, escribe:
 ## Parámetros
 
 **tipoFondo (string):**
-- Tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta"
+- Tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta", "retornoTotal"
 
 **nombreFondo (string):**
 - Nombre del fondo a consultar (ej: "Balanz Money Market USD - Clase A")
@@ -38,11 +38,12 @@ En cualquier celda de la hoja, escribe:
 | `=fci("rentaFija"; "Pionero Renta"; "2023-05-01")` | Valor cuotaparte del fondo Pionero Renta para la fecha indicada |
 | `=fci("rentaVariable"; "Alpha Acciones"; ; "patrimonio")` | Patrimonio actual del fondo Alpha Acciones |
 | `=fci("rentaMixta"; "Galileo Income"; ; "ccp")` | Cantidad de cuotapartes actual del fondo Galileo Income |
+| `=fci("retornoTotal"; "Cocos Pesos Plus - Clase A")` | Valor cuotaparte actual del fondo en la categoría retorno total |
 
 ## Errores comunes
 
 **Tipo de fondo inválido**  
-"Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta."
+"Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta, retornoTotal."
 
 **Fondo no encontrado**  
 "Fondo 'xyz' no encontrado para el tipo 'abc'. Algunos fondos disponibles: Balanz Money Market USD - Clase A, Schroder Liquidez - Clase B..."

--- a/src/fci.js
+++ b/src/fci.js
@@ -70,9 +70,9 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
   var campoDatos = campo ? campo.toString().toLowerCase().trim() : 'vcp';
   
   // Validar tipo de fondo
-  var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta'];
+  var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta', 'retornototal'];
   if (!tiposPermitidos.includes(tipo.replace(/\s+/g, '').replace(/[óo]/, 'o'))) {
-    throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta.");
+    throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta, retornoTotal.");
   }
   
   // Convertir tipo a formato de API
@@ -82,6 +82,7 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     case 'rentavariable': tipoAPI = 'rentaVariable'; break;
     case 'rentafija': tipoAPI = 'rentaFija'; break;
     case 'rentamixta': tipoAPI = 'rentaMixta'; break;
+    case 'retornototal': tipoAPI = 'retornoTotal'; break;
   }
   
   // Validar el campo a consultar

--- a/src/fci.js
+++ b/src/fci.js
@@ -1,7 +1,7 @@
 /**
  * Obtiene información de Fondos Comunes de Inversión (FCI) de Argentina.
  *
- * @param {string} tipoFondo El tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta"
+ * @param {string} tipoFondo El tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta", "retornoTotal"
  * @param {string} nombreFondo El nombre del fondo a consultar (ej: "Balanz Money Market USD - Clase A")
  * @param {string} fecha [Opcional] Fecha en formato 'YYYY-MM-DD'. Si no se proporciona, devuelve la información más reciente.
  * @param {string} campo [Opcional] Campo a consultar: "vcp" (valor cuotaparte), "ccp" (cantidad cuotapartes), "patrimonio". Por defecto: "vcp".
@@ -178,7 +178,7 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
  */
 function fciLista() {
   // Tipos de fondos a consultar
-  var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta'];
+  var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta', 'retornoTotal'];
   
   // Matriz para almacenar todos los fondos
   var todosLosFondos = [['Nombre del Fondo', 'Tipo de Fondo', 'Valor Cuotaparte']];
@@ -215,6 +215,7 @@ function fciLista() {
             case 'rentaVariable': nombreFormateado = 'Renta Variable'; break;
             case 'rentaFija': nombreFormateado = 'Renta Fija'; break;
             case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
+            case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
           }
           
           todosLosFondos.push([

--- a/tests/fci.test.js
+++ b/tests/fci.test.js
@@ -7,6 +7,7 @@ function createResponse(statusCode, body) {
 
 describe("fci", () => {
   let fci;
+  let fciLista;
   let fetchMock;
 
   beforeEach(() => {
@@ -20,7 +21,7 @@ describe("fci", () => {
     global.DriveApp = {};
     global.Logger = { log: jest.fn() };
 
-    ({ fci } = require("./test-wrapper"));
+    ({ fci, fciLista } = require("./test-wrapper"));
   });
 
   afterEach(() => {
@@ -93,5 +94,51 @@ describe("fci", () => {
     expect(result).toBe(321);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toContain("/rentaMixta/ultimo");
+  });
+
+  test("acepta retornoTotal y consulta su endpoint", () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, [
+        {
+          fondo: "Cocos Pesos Plus - Clase A",
+          vcp: 555.55,
+          ccp: 100,
+          patrimonio: 1000,
+        },
+      ])
+    );
+
+    const result = fci("retornoTotal", "Cocos Pesos Plus - Clase A");
+
+    expect(result).toBe(555.55);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain("/retornoTotal/ultimo");
+  });
+
+  test("fciLista incluye la categoría retornoTotal", () => {
+    fetchMock.mockImplementation((url) => {
+      if (url.includes("/retornoTotal/ultimo")) {
+        return createResponse(200, [
+          {
+            fondo: "Cocos Pesos Plus - Clase A",
+            vcp: 777.77,
+          },
+        ]);
+      }
+      return createResponse(200, []);
+    });
+
+    const result = fciLista();
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/retornoTotal/ultimo"),
+      expect.any(Object)
+    );
+    expect(result).toContainEqual([
+      "Cocos Pesos Plus - Clase A",
+      "Retorno Total",
+      777.77,
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `retornoTotal` as a new valid `tipoFondo` in the `=fci()` helper, mapping to the `retornoTotal` endpoint of the [ArgentinaDatos API](https://api.argentinadatos.com)
- Updates documentation with the new fund type, a usage example, and the updated error message

Implements enzonotario/esjs-argentina-datos#15

## What's new

The `=fci()` formula now accepts `"retornoTotal"` as a `tipoFondo`, hitting the `/v1/finanzas/fci/retornoTotal/` API endpoint. All existing parameters (`nombreFondo`, `fecha`, `campo`) work the same way as with other fund types.

## Why Cocos Pesos Plus is now usable

The fund **Cocos Pesos Plus - Clase A** is not listed under `rentaFija` — it belongs to the `retornoTotal` category in the ArgentinaDatos API. Before this change, the `=fci()` helper had no way to query that category, so any attempt to find the fund would fail with a "fondo no encontrado" error regardless of which type was used. With `retornoTotal` now supported, the fund is reachable via:

```
=fci("retornoTotal"; "Cocos Pesos Plus - Clase A")
```

