### PR TITLE
Add SPCX CEDEAR mapping with 50:1 ratio

### DIFF
--- a/data/cedears.json
+++ b/data/cedears.json
@@ -1695,6 +1695,11 @@
     "Ratio": "1:2"
   },
   {
+    "Cedears": "SPCX",
+    "Name": "Space Exploration Technologies Corp.",
+    "Ratio": "50"
+  },
+  {
     "Cedears": "SPGI",
     "Name": "S&P Global Inc",
     "Ratio": "45"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the CEDEAR mapping for **SPCX** (Space Exploration Technologies Corp. / SpaceX) to `data/cedears.json` with a **50:1** ratio.

## Changes

- New entry in `data/cedears.json`:
  - **Symbol:** `SPCX`
  - **Name:** Space Exploration Technologies Corp.
  - **Ratio:** `50` (50:1, consistent with other CEDEARs in the file)

## Notes

This follows the existing JSON format where ratios like 50:1 are stored as `"50"`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f478c40-9b11-4ff7-8738-dd1e88ff303f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f478c40-9b11-4ff7-8738-dd1e88ff303f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

