### PR TITLE
fix: auditoría P0 — fechas, errores y docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,16 @@ Forzar recálculo:
 - [src/criptoya.js](src/criptoya.js) – Código fuente para comparador de precios de criptomonedas
 - [src/bcra.js](src/bcra.js) – Código fuente para variables del Banco Central
 - [src/caucion.js](src/caucion.js) – Código fuente para cálculo de cauciones
+- [src/fecha.js](src/fecha.js) – Utilidades compartidas de parseo de fechas (YYYY-MM-DD y DD/MM/YYYY)
 - [all-in-one.js](all-in-one.js) – Archivo único con todas las funciones combinadas
 
 ## Desarrollo
 
-- Ejecutar 'npm run build' para generar [all-in-one.js](all-in-one.js)
-- Ejecutar 'npm run test' para ejecutar tests unitarios [tests\all-in-one.test.js](atests\all-in-one.test.js)
+```bash
+npm install
+npm run build   # genera all-in-one.js a partir de src/
+npm test        # requiere haber corrido build antes
+```
+
+- Tests unitarios: [tests/](tests/) (`fci.test.js`, `fecha.test.js`, `dolar.test.js`, `all-in-one.test.js`)
+- Siempre ejecutar `npm run build` después de modificar archivos en `src/`

--- a/all-in-one.js
+++ b/all-in-one.js
@@ -1,5 +1,5 @@
 // Archivo consolidado generado automáticamente
-// Fecha de generación: 2026-05-22T11:38:59.406Z
+// Fecha de generación: 2026-07-09T12:03:19.736Z
 
 // Namespace para constantes compartidas
 var CONSTANTS = {};
@@ -991,80 +991,26 @@ function dolar_historico_todos(fecha) {
  *
  * @param {string} tipoFondo El tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta", "retornoTotal"
  * @param {string} nombreFondo El nombre del fondo a consultar (ej: "Balanz Money Market USD - Clase A")
- * @param {string} fecha [Opcional] Fecha en formato 'YYYY-MM-DD'. Si no se proporciona, devuelve la información más reciente.
+ * @param {string} fecha [Opcional] Fecha en formato 'YYYY-MM-DD' o 'DD/MM/YYYY'. Si no se proporciona, devuelve la información más reciente.
  * @param {string} campo [Opcional] Campo a consultar: "vcp" (valor cuotaparte), "ccp" (cantidad cuotapartes), "patrimonio". Por defecto: "vcp".
  * @return El valor solicitado para el fondo especificado.
  * @customfunction
  */
 function fci(tipoFondo, nombreFondo, fecha, campo) {
-  function esFechaValida(year, month, day) {
-    if (month < 1 || month > 12 || day < 1 || day > 31) {
-      return false;
-    }
-    var fechaUTC = new Date(Date.UTC(year, month - 1, day));
-    var fechaLocal = new Date(year, month - 1, day);
-    return fechaUTC.getUTCFullYear() === year &&
-           (fechaUTC.getUTCMonth() + 1) === month &&
-           fechaUTC.getUTCDate() === day &&
-           fechaLocal.getFullYear() === year &&
-           (fechaLocal.getMonth() + 1) === month &&
-           fechaLocal.getDate() === day;
-  }
-
-  function obtenerComponentesFecha(fechaInput) {
-    var year;
-    var month;
-    var day;
-
-    if (fechaInput instanceof Date) {
-      if (isNaN(fechaInput.getTime())) {
-        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-      }
-      year = fechaInput.getFullYear();
-      month = fechaInput.getMonth() + 1;
-      day = fechaInput.getDate();
-    } else {
-      var fechaStr = fechaInput.toString().trim();
-      var matchISO = fechaStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-      var matchUS = fechaStr.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
-
-      if (matchISO) {
-        year = parseInt(matchISO[1], 10);
-        month = parseInt(matchISO[2], 10);
-        day = parseInt(matchISO[3], 10);
-      } else if (matchUS) {
-        month = parseInt(matchUS[1], 10);
-        day = parseInt(matchUS[2], 10);
-        year = parseInt(matchUS[3], 10);
-      } else {
-        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-      }
-    }
-
-    if (!esFechaValida(year, month, day)) {
-      throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-    }
-
-    return {
-      year: year.toString(),
-      month: month.toString().padStart(2, '0'),
-      day: day.toString().padStart(2, '0')
-    };
-  }
-
   // Normalizo entradas
   var tipo = tipoFondo ? tipoFondo.toString().toLowerCase().trim() : '';
   var nombre = nombreFondo ? nombreFondo.toString().trim() : '';
   var campoDatos = campo ? campo.toString().toLowerCase().trim() : 'vcp';
-  
-  // Validar tipo de fondo
+
+  // Validar tipo de fondo (normalización con replace global)
+  var tipoNormalizado = tipo.replace(/\s+/g, '').replace(/[óo]/g, 'o');
   var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta', 'retornototal'];
-  if (!tiposPermitidos.includes(tipo.replace(/\s+/g, '').replace(/[óo]/, 'o'))) {
+  if (!tiposPermitidos.includes(tipoNormalizado)) {
     throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta, retornoTotal.");
   }
-  
+
   // Convertir tipo a formato de API
-  var tipoAPI = tipo.replace(/\s+/g, '').replace(/[óo]/, 'o');
+  var tipoAPI = tipoNormalizado;
   switch (tipoAPI) {
     case 'mercadodinero': tipoAPI = 'mercadoDinero'; break;
     case 'rentavariable': tipoAPI = 'rentaVariable'; break;
@@ -1072,18 +1018,18 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     case 'rentamixta': tipoAPI = 'rentaMixta'; break;
     case 'retornototal': tipoAPI = 'retornoTotal'; break;
   }
-  
+
   // Validar el campo a consultar
   var camposPermitidos = ['vcp', 'ccp', 'patrimonio'];
   if (!camposPermitidos.includes(campoDatos)) {
     throw new Error("Campo inválido. Campos permitidos: vcp (valor cuotaparte), ccp (cantidad cuotapartes), patrimonio.");
   }
-  
+
   // Validar que se haya proporcionado un nombre de fondo
   if (!nombre) {
     throw new Error("Debe especificar un nombre de fondo.");
   }
-  
+
   // Construir URL según si se proporciona fecha o no
   var url;
   if (fecha) {
@@ -1091,25 +1037,25 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
       var componentesFecha = obtenerComponentesFecha(fecha);
       url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/' + componentesFecha.year + '/' + componentesFecha.month + '/' + componentesFecha.day + '/';
     } catch (e) {
-      throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+      throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
     }
   } else {
     url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/ultimo';
   }
-  
+
   try {
     // Consulta al API
     var respuesta = UrlFetchApp.fetch(url, {
       muteHttpExceptions: true
     });
-    
+
     // Verificar si la respuesta es válida
     if (respuesta.getResponseCode() !== 200) {
       throw new Error("Error al consultar la API: Código " + respuesta.getResponseCode() + ". Verifique los parámetros.");
     }
-    
+
     var datos = JSON.parse(respuesta.getContentText());
-    
+
     function esFondoValido(item) {
       return item.fondo && !item.fondo.startsWith("Region:") &&
           !item.fondo.startsWith("Duration:") &&
@@ -1168,7 +1114,7 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     }
     throw new Error("Error al consultar información de '" + tipoFondo + "': " + e.message);
   }
-} 
+}
 
 /**
  * Obtiene la lista completa de Fondos Comunes de Inversión (FCI) disponibles en Argentina.
@@ -1179,34 +1125,34 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
 function fciLista() {
   // Tipos de fondos a consultar
   var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta', 'retornoTotal'];
-  
+
   // Matriz para almacenar todos los fondos
   var todosLosFondos = [['Nombre del Fondo', 'Tipo de Fondo', 'Valor Cuotaparte']];
-  
+
   // Recorrer cada tipo de fondo
   tipos.forEach(function(tipo) {
     try {
       // Construir URL para obtener la lista de fondos
       var url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipo + '/ultimo';
-      
+
       // Consultar la API
       var respuesta = UrlFetchApp.fetch(url, {
         muteHttpExceptions: true
       });
-      
+
       // Verificar si la respuesta es válida
       if (respuesta.getResponseCode() === 200) {
         var datos = JSON.parse(respuesta.getContentText());
-        
+
         // Filtrar solo los fondos válidos (no categorías)
         var fondosValidos = datos.filter(function(d) {
-          return d.fondo && 
-                 !d.fondo.startsWith("Region:") && 
-                 !d.fondo.startsWith("Duration:") && 
-                 !d.fondo.startsWith("Benchmark:") && 
+          return d.fondo &&
+                 !d.fondo.startsWith("Region:") &&
+                 !d.fondo.startsWith("Duration:") &&
+                 !d.fondo.startsWith("Benchmark:") &&
                  !d.fondo.startsWith("Moneda:");
         });
-        
+
         // Agregar cada fondo a la matriz de resultados
         fondosValidos.forEach(function(fondo) {
           var nombreFormateado = tipo;
@@ -1217,7 +1163,7 @@ function fciLista() {
             case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
             case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
           }
-          
+
           todosLosFondos.push([
             fondo.fondo,
             nombreFormateado,
@@ -1230,9 +1176,9 @@ function fciLista() {
       Logger.log("Error al consultar fondos de tipo '" + tipo + "': " + e.message);
     }
   });
-  
+
   return todosLosFondos;
-} 
+}
 
 // ================ fecha.js ================
 /**
@@ -1346,19 +1292,18 @@ function inflacion(fecha) {
   }
 
   // Si no se proporciona fecha, devolver el valor más reciente
+  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return datos[0].valor;
   }
 
   var fechaFormateada;
-  var fechaBusqueda;
   try {
     fechaFormateada = formatearFechaISO(fecha);
-    fechaBusqueda = parsearFechaLocal(fecha);
   } catch (e) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
@@ -1372,12 +1317,12 @@ function inflacion(fecha) {
 
   // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
-    return new Date(d.fecha) <= fechaBusqueda;
+    return d.fecha <= fechaFormateada;
   });
 
   if (fechasMenores.length > 0) {
     fechasMenores.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return fechasMenores[0].valor;
@@ -1385,7 +1330,7 @@ function inflacion(fecha) {
 
   // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
-    return new Date(a.fecha) - new Date(b.fecha);
+    return a.fecha.localeCompare(b.fecha);
   });
 
   return datos[0].valor;
@@ -1727,25 +1672,24 @@ function rendimientos(moneda, proveedor) {
   var url = 'https://api.argentinadatos.com/v1/finanzas/rendimientos';
   var respuesta = UrlFetchApp.fetch(url);
   var datos = JSON.parse(respuesta.getContentText());
-  
+
   // Normalizo entradas
   var crypto = moneda ? moneda.toString().toUpperCase().trim() : '';
   var exchange = proveedor ? proveedor.toString().toLowerCase().trim() : '';
-  
+
   // Verificar si se proporcionó la moneda
   if (!crypto) {
     throw new Error("Debe especificar una criptomoneda o moneda fiat.");
   }
-  
+
   // Si se especifica un proveedor, buscar solo en ese proveedor
   if (exchange) {
     var proveedorEncontrado = false;
-    var rendimientoEncontrado = false;
-    
+
     for (var i = 0; i < datos.length; i++) {
       if (datos[i].entidad === exchange) {
         proveedorEncontrado = true;
-        
+
         if (!datos[i].rendimientos || !datos[i].rendimientos.length) {
           continue;
         }
@@ -1753,16 +1697,15 @@ function rendimientos(moneda, proveedor) {
         // Buscar la moneda en los rendimientos del proveedor
         for (var j = 0; j < datos[i].rendimientos.length; j++) {
           if (datos[i].rendimientos[j].moneda.toUpperCase() === crypto) {
-            rendimientoEncontrado = true;
             return datos[i].rendimientos[j].apy;
           }
         }
-        
+
         // Si llegamos aquí, no se encontró la moneda en este proveedor
         throw new Error("La moneda '" + moneda + "' no está disponible en el proveedor '" + proveedor + "'.");
       }
     }
-    
+
     // Si llegamos aquí, no se encontró el proveedor
     if (!proveedorEncontrado) {
       // Obtener la lista de proveedores disponibles
@@ -1772,29 +1715,27 @@ function rendimientos(moneda, proveedor) {
   } else {
     // Si no se especifica proveedor, buscar el mejor rendimiento para la moneda
     var mejorApy = -1;
-    var mejorProveedor = "";
     var monedaEncontrada = false;
-    
-    for (var i = 0; i < datos.length; i++) {
-      var proveedor = datos[i];
 
-      if (!proveedor.rendimientos || !proveedor.rendimientos.length) {
+    for (var i = 0; i < datos.length; i++) {
+      var itemProveedor = datos[i];
+
+      if (!itemProveedor.rendimientos || !itemProveedor.rendimientos.length) {
         continue;
       }
 
-      for (var j = 0; j < proveedor.rendimientos.length; j++) {
-        if (proveedor.rendimientos[j].moneda.toUpperCase() === crypto) {
+      for (var j = 0; j < itemProveedor.rendimientos.length; j++) {
+        if (itemProveedor.rendimientos[j].moneda.toUpperCase() === crypto) {
           monedaEncontrada = true;
-          var apy = proveedor.rendimientos[j].apy;
-          
+          var apy = itemProveedor.rendimientos[j].apy;
+
           if (apy > mejorApy) {
             mejorApy = apy;
-            mejorProveedor = proveedor.entidad;
           }
         }
       }
     }
-    
+
     // Verificar si se encontró la moneda
     if (!monedaEncontrada) {
       // Obtener lista de monedas disponibles (sin duplicados)
@@ -1802,25 +1743,26 @@ function rendimientos(moneda, proveedor) {
       for (var i = 0; i < datos.length; i++) {
         if (!datos[i].rendimientos) continue;
         for (var j = 0; j < datos[i].rendimientos.length; j++) {
-          var moneda = datos[i].rendimientos[j].moneda.toUpperCase();
-          if (monedasDisponibles.indexOf(moneda) === -1) {
-            monedasDisponibles.push(moneda);
+          var mon = datos[i].rendimientos[j].moneda.toUpperCase();
+          if (monedasDisponibles.indexOf(mon) === -1) {
+            monedasDisponibles.push(mon);
           }
         }
       }
       monedasDisponibles.sort();
-      
+
       throw new Error("Moneda '" + moneda + "' no encontrada. Algunas monedas disponibles: " + monedasDisponibles.slice(0, 15).join(", ") + "...");
     }
-    
+
     // Si el mejor APY es 0, indicar que no hay rendimiento disponible
     if (mejorApy === 0) {
       return 0; // No hay rendimiento disponible para esta moneda
     }
-    
+
     return mejorApy;
   }
-} 
+}
+
 // ================ riesgopais.js ================
 /**
  * Obtiene el valor del riesgo país de Argentina.
@@ -1840,19 +1782,18 @@ function riesgopais(fecha) {
   }
 
   // Si no se proporciona fecha, devolver el valor más reciente
+  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return datos[0].valor;
   }
 
   var fechaFormateada;
-  var fechaBusqueda;
   try {
     fechaFormateada = formatearFechaISO(fecha);
-    fechaBusqueda = parsearFechaLocal(fecha);
   } catch (e) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
@@ -1866,12 +1807,12 @@ function riesgopais(fecha) {
 
   // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
-    return new Date(d.fecha) <= fechaBusqueda;
+    return d.fecha <= fechaFormateada;
   });
 
   if (fechasMenores.length > 0) {
     fechasMenores.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return fechasMenores[0].valor;
@@ -1879,7 +1820,7 @@ function riesgopais(fecha) {
 
   // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
-    return new Date(a.fecha) - new Date(b.fecha);
+    return a.fecha.localeCompare(b.fecha);
   });
 
   return datos[0].valor;
@@ -1972,19 +1913,18 @@ function uva(fecha) {
   }
 
   // Si no se proporciona fecha, devolver el valor más reciente
+  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return datos[0].valor;
   }
 
   var fechaFormateada;
-  var fechaBusqueda;
   try {
     fechaFormateada = formatearFechaISO(fecha);
-    fechaBusqueda = parsearFechaLocal(fecha);
   } catch (e) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
@@ -1998,12 +1938,12 @@ function uva(fecha) {
 
   // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
-    return new Date(d.fecha) <= fechaBusqueda;
+    return d.fecha <= fechaFormateada;
   });
 
   if (fechasMenores.length > 0) {
     fechasMenores.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return fechasMenores[0].valor;
@@ -2011,7 +1951,7 @@ function uva(fecha) {
 
   // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
-    return new Date(a.fecha) - new Date(b.fecha);
+    return a.fecha.localeCompare(b.fecha);
   });
 
   return datos[0].valor;

--- a/build.js
+++ b/build.js
@@ -9,6 +9,7 @@ function getAllJsFiles() {
     const srcDir = path.join(__dirname, 'src');
     return fs.readdirSync(srcDir)
         .filter(file => file.endsWith('.js') && !excludeFiles.includes(file))
+        .sort()
         .map(file => path.join(srcDir, file));
 }
 

--- a/doc/CAUCION.md
+++ b/doc/CAUCION.md
@@ -44,10 +44,11 @@ En cualquier celda de la hoja, escribe:
 | `=caucion(30, 150%, 500000)` | Caución tomadora a 30 días con TNA 150% por $500.000 |
 | `=caucionColocadora(15, 130%, 750000)` | Caución colocadora a 15 días con TNA 130% por $750.000 |
 | `=caucionTomadora(1, 140%, 1500000, 3.5%)` | Caución tomadora a 1 día con TNA 140% por $1.500.000 y arancel personalizado de 3.5% |
-| `=caucion(-10, 125%, 2000000, 2, 4.5%)` | Caución colocadora a 10 días con TNA 125% por $2.000.000 y aranceles personalizados de 4.5% |
+| `=caucion(-10, 125%, 2000000, 2%, 4.5%)` | Caución colocadora a 10 días con TNA 125% por $2.000.000 y aranceles personalizados (2% colocadora, 4.5% tomadora) |
 
 #### Notas
 - Las funciones devuelven el importe neto final de la operación incluyendo todos los gastos (arancel, derechos de mercado, gastos de garantía e IVA)
 - Los gastos de garantía solo aplican para cauciones tomadoras
 - El IVA se calcula sobre todos los gastos (21%)
 - Los derechos de mercado y gastos de garantía se calculan a una tasa diaria proporcional al plazo de la operación (hasta 90 días)
+- **Importante:** TNA y aranceles deben ingresarse como porcentaje de Sheets (`120%`, `1.5%`). Un número sin `%` (ej. `2`) se interpreta como 200%, no como 2%

--- a/doc/FCI.md
+++ b/doc/FCI.md
@@ -20,7 +20,8 @@ En cualquier celda de la hoja, escribe:
 
 **fecha (string):** [Opcional]
 - Fecha para la cual se quiere obtener la información
-- Formato aceptado: "YYYY-MM-DD" o "MM/DD/YYYY"
+- Formato aceptado: "YYYY-MM-DD" o "DD/MM/YYYY" (formato argentino)
+- También acepta celdas con tipo fecha de Google Sheets
 - Si se omite, devuelve la información más reciente
 
 **campo (string):** [Opcional]
@@ -36,6 +37,7 @@ En cualquier celda de la hoja, escribe:
 |---------|-------------|
 | `=fci("mercadoDinero"; "Balanz Money Market USD - Clase A")` | Valor cuotaparte actual del fondo Balanz Money Market USD |
 | `=fci("rentaFija"; "Pionero Renta"; "2023-05-01")` | Valor cuotaparte del fondo Pionero Renta para la fecha indicada |
+| `=fci("rentaFija"; "Pionero Renta"; "01/05/2023")` | Mismo valor usando formato DD/MM/YYYY |
 | `=fci("rentaVariable"; "Alpha Acciones"; ; "patrimonio")` | Patrimonio actual del fondo Alpha Acciones |
 | `=fci("rentaMixta"; "Galileo Income"; ; "ccp")` | Cantidad de cuotapartes actual del fondo Galileo Income |
 | `=fci("retornoTotal"; "Cocos Pesos Plus - Clase A")` | Valor cuotaparte actual del fondo en la categoría retorno total |
@@ -52,7 +54,7 @@ En cualquier celda de la hoja, escribe:
 "Campo inválido. Campos permitidos: vcp (valor cuotaparte), ccp (cantidad cuotapartes), patrimonio."
 
 **Fecha inválida**  
-"Fecha inválida: 'xyz'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'."
+"Fecha inválida: 'xyz'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'."
 
 **Sin valor disponible**  
 "El fondo 'xyz' no tiene valor para el campo 'abc'."

--- a/src/fci.js
+++ b/src/fci.js
@@ -3,80 +3,26 @@
  *
  * @param {string} tipoFondo El tipo de fondo a consultar: "mercadoDinero", "rentaVariable", "rentaFija", "rentaMixta", "retornoTotal"
  * @param {string} nombreFondo El nombre del fondo a consultar (ej: "Balanz Money Market USD - Clase A")
- * @param {string} fecha [Opcional] Fecha en formato 'YYYY-MM-DD'. Si no se proporciona, devuelve la información más reciente.
+ * @param {string} fecha [Opcional] Fecha en formato 'YYYY-MM-DD' o 'DD/MM/YYYY'. Si no se proporciona, devuelve la información más reciente.
  * @param {string} campo [Opcional] Campo a consultar: "vcp" (valor cuotaparte), "ccp" (cantidad cuotapartes), "patrimonio". Por defecto: "vcp".
  * @return El valor solicitado para el fondo especificado.
  * @customfunction
  */
 function fci(tipoFondo, nombreFondo, fecha, campo) {
-  function esFechaValida(year, month, day) {
-    if (month < 1 || month > 12 || day < 1 || day > 31) {
-      return false;
-    }
-    var fechaUTC = new Date(Date.UTC(year, month - 1, day));
-    var fechaLocal = new Date(year, month - 1, day);
-    return fechaUTC.getUTCFullYear() === year &&
-           (fechaUTC.getUTCMonth() + 1) === month &&
-           fechaUTC.getUTCDate() === day &&
-           fechaLocal.getFullYear() === year &&
-           (fechaLocal.getMonth() + 1) === month &&
-           fechaLocal.getDate() === day;
-  }
-
-  function obtenerComponentesFecha(fechaInput) {
-    var year;
-    var month;
-    var day;
-
-    if (fechaInput instanceof Date) {
-      if (isNaN(fechaInput.getTime())) {
-        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-      }
-      year = fechaInput.getFullYear();
-      month = fechaInput.getMonth() + 1;
-      day = fechaInput.getDate();
-    } else {
-      var fechaStr = fechaInput.toString().trim();
-      var matchISO = fechaStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-      var matchUS = fechaStr.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
-
-      if (matchISO) {
-        year = parseInt(matchISO[1], 10);
-        month = parseInt(matchISO[2], 10);
-        day = parseInt(matchISO[3], 10);
-      } else if (matchUS) {
-        month = parseInt(matchUS[1], 10);
-        day = parseInt(matchUS[2], 10);
-        year = parseInt(matchUS[3], 10);
-      } else {
-        throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-      }
-    }
-
-    if (!esFechaValida(year, month, day)) {
-      throw new Error("Fecha inválida: '" + fechaInput + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
-    }
-
-    return {
-      year: year.toString(),
-      month: month.toString().padStart(2, '0'),
-      day: day.toString().padStart(2, '0')
-    };
-  }
-
   // Normalizo entradas
   var tipo = tipoFondo ? tipoFondo.toString().toLowerCase().trim() : '';
   var nombre = nombreFondo ? nombreFondo.toString().trim() : '';
   var campoDatos = campo ? campo.toString().toLowerCase().trim() : 'vcp';
-  
-  // Validar tipo de fondo
+
+  // Validar tipo de fondo (normalización con replace global)
+  var tipoNormalizado = tipo.replace(/\s+/g, '').replace(/[óo]/g, 'o');
   var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta', 'retornototal'];
-  if (!tiposPermitidos.includes(tipo.replace(/\s+/g, '').replace(/[óo]/, 'o'))) {
+  if (!tiposPermitidos.includes(tipoNormalizado)) {
     throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta, retornoTotal.");
   }
-  
+
   // Convertir tipo a formato de API
-  var tipoAPI = tipo.replace(/\s+/g, '').replace(/[óo]/, 'o');
+  var tipoAPI = tipoNormalizado;
   switch (tipoAPI) {
     case 'mercadodinero': tipoAPI = 'mercadoDinero'; break;
     case 'rentavariable': tipoAPI = 'rentaVariable'; break;
@@ -84,18 +30,18 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     case 'rentamixta': tipoAPI = 'rentaMixta'; break;
     case 'retornototal': tipoAPI = 'retornoTotal'; break;
   }
-  
+
   // Validar el campo a consultar
   var camposPermitidos = ['vcp', 'ccp', 'patrimonio'];
   if (!camposPermitidos.includes(campoDatos)) {
     throw new Error("Campo inválido. Campos permitidos: vcp (valor cuotaparte), ccp (cantidad cuotapartes), patrimonio.");
   }
-  
+
   // Validar que se haya proporcionado un nombre de fondo
   if (!nombre) {
     throw new Error("Debe especificar un nombre de fondo.");
   }
-  
+
   // Construir URL según si se proporciona fecha o no
   var url;
   if (fecha) {
@@ -103,25 +49,25 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
       var componentesFecha = obtenerComponentesFecha(fecha);
       url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/' + componentesFecha.year + '/' + componentesFecha.month + '/' + componentesFecha.day + '/';
     } catch (e) {
-      throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'MM/DD/YYYY'.");
+      throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
     }
   } else {
     url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/ultimo';
   }
-  
+
   try {
     // Consulta al API
     var respuesta = UrlFetchApp.fetch(url, {
       muteHttpExceptions: true
     });
-    
+
     // Verificar si la respuesta es válida
     if (respuesta.getResponseCode() !== 200) {
       throw new Error("Error al consultar la API: Código " + respuesta.getResponseCode() + ". Verifique los parámetros.");
     }
-    
+
     var datos = JSON.parse(respuesta.getContentText());
-    
+
     function esFondoValido(item) {
       return item.fondo && !item.fondo.startsWith("Region:") &&
           !item.fondo.startsWith("Duration:") &&
@@ -180,7 +126,7 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     }
     throw new Error("Error al consultar información de '" + tipoFondo + "': " + e.message);
   }
-} 
+}
 
 /**
  * Obtiene la lista completa de Fondos Comunes de Inversión (FCI) disponibles en Argentina.
@@ -191,34 +137,34 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
 function fciLista() {
   // Tipos de fondos a consultar
   var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta', 'retornoTotal'];
-  
+
   // Matriz para almacenar todos los fondos
   var todosLosFondos = [['Nombre del Fondo', 'Tipo de Fondo', 'Valor Cuotaparte']];
-  
+
   // Recorrer cada tipo de fondo
   tipos.forEach(function(tipo) {
     try {
       // Construir URL para obtener la lista de fondos
       var url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipo + '/ultimo';
-      
+
       // Consultar la API
       var respuesta = UrlFetchApp.fetch(url, {
         muteHttpExceptions: true
       });
-      
+
       // Verificar si la respuesta es válida
       if (respuesta.getResponseCode() === 200) {
         var datos = JSON.parse(respuesta.getContentText());
-        
+
         // Filtrar solo los fondos válidos (no categorías)
         var fondosValidos = datos.filter(function(d) {
-          return d.fondo && 
-                 !d.fondo.startsWith("Region:") && 
-                 !d.fondo.startsWith("Duration:") && 
-                 !d.fondo.startsWith("Benchmark:") && 
+          return d.fondo &&
+                 !d.fondo.startsWith("Region:") &&
+                 !d.fondo.startsWith("Duration:") &&
+                 !d.fondo.startsWith("Benchmark:") &&
                  !d.fondo.startsWith("Moneda:");
         });
-        
+
         // Agregar cada fondo a la matriz de resultados
         fondosValidos.forEach(function(fondo) {
           var nombreFormateado = tipo;
@@ -229,7 +175,7 @@ function fciLista() {
             case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
             case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
           }
-          
+
           todosLosFondos.push([
             fondo.fondo,
             nombreFormateado,
@@ -242,6 +188,6 @@ function fciLista() {
       Logger.log("Error al consultar fondos de tipo '" + tipo + "': " + e.message);
     }
   });
-  
+
   return todosLosFondos;
-} 
+}

--- a/src/inflacion.js
+++ b/src/inflacion.js
@@ -16,19 +16,18 @@ function inflacion(fecha) {
   }
 
   // Si no se proporciona fecha, devolver el valor más reciente
+  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return datos[0].valor;
   }
 
   var fechaFormateada;
-  var fechaBusqueda;
   try {
     fechaFormateada = formatearFechaISO(fecha);
-    fechaBusqueda = parsearFechaLocal(fecha);
   } catch (e) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
@@ -42,12 +41,12 @@ function inflacion(fecha) {
 
   // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
-    return new Date(d.fecha) <= fechaBusqueda;
+    return d.fecha <= fechaFormateada;
   });
 
   if (fechasMenores.length > 0) {
     fechasMenores.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return fechasMenores[0].valor;
@@ -55,7 +54,7 @@ function inflacion(fecha) {
 
   // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
-    return new Date(a.fecha) - new Date(b.fecha);
+    return a.fecha.localeCompare(b.fecha);
   });
 
   return datos[0].valor;

--- a/src/rendimientos.js
+++ b/src/rendimientos.js
@@ -11,25 +11,24 @@ function rendimientos(moneda, proveedor) {
   var url = 'https://api.argentinadatos.com/v1/finanzas/rendimientos';
   var respuesta = UrlFetchApp.fetch(url);
   var datos = JSON.parse(respuesta.getContentText());
-  
+
   // Normalizo entradas
   var crypto = moneda ? moneda.toString().toUpperCase().trim() : '';
   var exchange = proveedor ? proveedor.toString().toLowerCase().trim() : '';
-  
+
   // Verificar si se proporcionó la moneda
   if (!crypto) {
     throw new Error("Debe especificar una criptomoneda o moneda fiat.");
   }
-  
+
   // Si se especifica un proveedor, buscar solo en ese proveedor
   if (exchange) {
     var proveedorEncontrado = false;
-    var rendimientoEncontrado = false;
-    
+
     for (var i = 0; i < datos.length; i++) {
       if (datos[i].entidad === exchange) {
         proveedorEncontrado = true;
-        
+
         if (!datos[i].rendimientos || !datos[i].rendimientos.length) {
           continue;
         }
@@ -37,16 +36,15 @@ function rendimientos(moneda, proveedor) {
         // Buscar la moneda en los rendimientos del proveedor
         for (var j = 0; j < datos[i].rendimientos.length; j++) {
           if (datos[i].rendimientos[j].moneda.toUpperCase() === crypto) {
-            rendimientoEncontrado = true;
             return datos[i].rendimientos[j].apy;
           }
         }
-        
+
         // Si llegamos aquí, no se encontró la moneda en este proveedor
         throw new Error("La moneda '" + moneda + "' no está disponible en el proveedor '" + proveedor + "'.");
       }
     }
-    
+
     // Si llegamos aquí, no se encontró el proveedor
     if (!proveedorEncontrado) {
       // Obtener la lista de proveedores disponibles
@@ -56,29 +54,27 @@ function rendimientos(moneda, proveedor) {
   } else {
     // Si no se especifica proveedor, buscar el mejor rendimiento para la moneda
     var mejorApy = -1;
-    var mejorProveedor = "";
     var monedaEncontrada = false;
-    
-    for (var i = 0; i < datos.length; i++) {
-      var proveedor = datos[i];
 
-      if (!proveedor.rendimientos || !proveedor.rendimientos.length) {
+    for (var i = 0; i < datos.length; i++) {
+      var itemProveedor = datos[i];
+
+      if (!itemProveedor.rendimientos || !itemProveedor.rendimientos.length) {
         continue;
       }
 
-      for (var j = 0; j < proveedor.rendimientos.length; j++) {
-        if (proveedor.rendimientos[j].moneda.toUpperCase() === crypto) {
+      for (var j = 0; j < itemProveedor.rendimientos.length; j++) {
+        if (itemProveedor.rendimientos[j].moneda.toUpperCase() === crypto) {
           monedaEncontrada = true;
-          var apy = proveedor.rendimientos[j].apy;
-          
+          var apy = itemProveedor.rendimientos[j].apy;
+
           if (apy > mejorApy) {
             mejorApy = apy;
-            mejorProveedor = proveedor.entidad;
           }
         }
       }
     }
-    
+
     // Verificar si se encontró la moneda
     if (!monedaEncontrada) {
       // Obtener lista de monedas disponibles (sin duplicados)
@@ -86,22 +82,22 @@ function rendimientos(moneda, proveedor) {
       for (var i = 0; i < datos.length; i++) {
         if (!datos[i].rendimientos) continue;
         for (var j = 0; j < datos[i].rendimientos.length; j++) {
-          var moneda = datos[i].rendimientos[j].moneda.toUpperCase();
-          if (monedasDisponibles.indexOf(moneda) === -1) {
-            monedasDisponibles.push(moneda);
+          var mon = datos[i].rendimientos[j].moneda.toUpperCase();
+          if (monedasDisponibles.indexOf(mon) === -1) {
+            monedasDisponibles.push(mon);
           }
         }
       }
       monedasDisponibles.sort();
-      
+
       throw new Error("Moneda '" + moneda + "' no encontrada. Algunas monedas disponibles: " + monedasDisponibles.slice(0, 15).join(", ") + "...");
     }
-    
+
     // Si el mejor APY es 0, indicar que no hay rendimiento disponible
     if (mejorApy === 0) {
       return 0; // No hay rendimiento disponible para esta moneda
     }
-    
+
     return mejorApy;
   }
-} 
+}

--- a/src/riesgopais.js
+++ b/src/riesgopais.js
@@ -16,19 +16,18 @@ function riesgopais(fecha) {
   }
 
   // Si no se proporciona fecha, devolver el valor más reciente
+  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return datos[0].valor;
   }
 
   var fechaFormateada;
-  var fechaBusqueda;
   try {
     fechaFormateada = formatearFechaISO(fecha);
-    fechaBusqueda = parsearFechaLocal(fecha);
   } catch (e) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
@@ -42,12 +41,12 @@ function riesgopais(fecha) {
 
   // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
-    return new Date(d.fecha) <= fechaBusqueda;
+    return d.fecha <= fechaFormateada;
   });
 
   if (fechasMenores.length > 0) {
     fechasMenores.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return fechasMenores[0].valor;
@@ -55,7 +54,7 @@ function riesgopais(fecha) {
 
   // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
-    return new Date(a.fecha) - new Date(b.fecha);
+    return a.fecha.localeCompare(b.fecha);
   });
 
   return datos[0].valor;

--- a/src/uva.js
+++ b/src/uva.js
@@ -16,19 +16,18 @@ function uva(fecha) {
   }
 
   // Si no se proporciona fecha, devolver el valor más reciente
+  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return datos[0].valor;
   }
 
   var fechaFormateada;
-  var fechaBusqueda;
   try {
     fechaFormateada = formatearFechaISO(fecha);
-    fechaBusqueda = parsearFechaLocal(fecha);
   } catch (e) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
@@ -42,12 +41,12 @@ function uva(fecha) {
 
   // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
-    return new Date(d.fecha) <= fechaBusqueda;
+    return d.fecha <= fechaFormateada;
   });
 
   if (fechasMenores.length > 0) {
     fechasMenores.sort(function(a, b) {
-      return new Date(b.fecha) - new Date(a.fecha);
+      return b.fecha.localeCompare(a.fecha);
     });
 
     return fechasMenores[0].valor;
@@ -55,7 +54,7 @@ function uva(fecha) {
 
   // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
-    return new Date(a.fecha) - new Date(b.fecha);
+    return a.fecha.localeCompare(b.fecha);
   });
 
   return datos[0].valor;

--- a/tests/fci.test.js
+++ b/tests/fci.test.js
@@ -51,7 +51,7 @@ describe("fci", () => {
     expect(fetchMock.mock.calls[0][0]).not.toContain("/rentaMixta/2026/04/12/");
   });
 
-  test("acepta MM/DD/YYYY y apunta al mismo endpoint normalizado", () => {
+  test("acepta DD/MM/YYYY y apunta al mismo endpoint normalizado", () => {
     fetchMock.mockReturnValue(
       createResponse(200, [
         {
@@ -63,11 +63,19 @@ describe("fci", () => {
       ])
     );
 
-    const result = fci("rentaMixta", "Cocos Rendimiento - Clase A", "04/13/2026");
+    const result = fci("rentaMixta", "Cocos Rendimiento - Clase A", "13/04/2026");
 
     expect(result).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toContain("/rentaMixta/2026/04/13/");
+  });
+
+  test("rechaza MM/DD/YYYY ambiguo (usa formato argentino DD/MM)", () => {
+    // 04/13/2026 se interpreta como día=4, mes=13 → inválido
+    expect(() =>
+      fci("rentaMixta", "Cocos Rendimiento - Clase A", "04/13/2026")
+    ).toThrow("Fecha inválida");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("rechaza fecha inválida y no consulta la API", () => {

--- a/tests/inflacion.test.js
+++ b/tests/inflacion.test.js
@@ -1,0 +1,54 @@
+function createResponse(body) {
+  return {
+    getResponseCode: () => 200,
+    getContentText: () => JSON.stringify(body),
+  };
+}
+
+describe("inflacion", () => {
+  let inflacion;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.UrlFetchApp = {
+      fetch: jest.fn().mockReturnValue(
+        createResponse([
+          { fecha: "2026-01-01", valor: 10 },
+          { fecha: "2026-03-01", valor: 12 },
+          { fecha: "2026-02-01", valor: 11 },
+        ])
+      ),
+    };
+    global.Utilities = {};
+    global.DriveApp = {};
+    global.Logger = { log: jest.fn() };
+    ({ inflacion } = require("./test-wrapper"));
+  });
+
+  afterEach(() => {
+    delete global.UrlFetchApp;
+    delete global.Utilities;
+    delete global.DriveApp;
+    delete global.Logger;
+  });
+
+  test("sin fecha devuelve el valor más reciente por string ISO", () => {
+    expect(inflacion()).toBe(12);
+  });
+
+  test("fecha exacta ISO", () => {
+    expect(inflacion("2026-02-01")).toBe(11);
+  });
+
+  test("fecha exacta DD/MM/YYYY", () => {
+    expect(inflacion("01/02/2026")).toBe(11);
+  });
+
+  test("fecha sin match exacto usa la anterior más cercana", () => {
+    expect(inflacion("2026-02-15")).toBe(11);
+  });
+
+  test("fecha anterior a todos los datos devuelve el más antiguo", () => {
+    expect(inflacion("2025-01-01")).toBe(10);
+  });
+});

--- a/tests/rendimientos.test.js
+++ b/tests/rendimientos.test.js
@@ -1,0 +1,59 @@
+function createResponse(body) {
+  return {
+    getResponseCode: () => 200,
+    getContentText: () => JSON.stringify(body),
+  };
+}
+
+describe("rendimientos", () => {
+  let rendimientos;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.UrlFetchApp = {
+      fetch: jest.fn().mockReturnValue(
+        createResponse([
+          {
+            entidad: "ripio",
+            rendimientos: [
+              { moneda: "USDT", apy: 5 },
+              { moneda: "BTC", apy: 1 },
+            ],
+          },
+          {
+            entidad: "buenbit",
+            rendimientos: [
+              { moneda: "USDT", apy: 8 },
+              { moneda: "ETH", apy: 3 },
+            ],
+          },
+        ])
+      ),
+    };
+    global.Utilities = {};
+    global.DriveApp = {};
+    global.Logger = { log: jest.fn() };
+    ({ rendimientos } = require("./test-wrapper"));
+  });
+
+  afterEach(() => {
+    delete global.UrlFetchApp;
+    delete global.Utilities;
+    delete global.DriveApp;
+    delete global.Logger;
+  });
+
+  test("devuelve el mejor APY cuando no hay proveedor", () => {
+    expect(rendimientos("USDT")).toBe(8);
+  });
+
+  test("error por moneda inexistente usa el ticker pedido (no el último del dataset)", () => {
+    expect(() => rendimientos("DOGE")).toThrow("Moneda 'DOGE' no encontrada");
+  });
+
+  test("error por moneda en proveedor específico usa el ticker pedido", () => {
+    expect(() => rendimientos("ETH", "ripio")).toThrow(
+      "La moneda 'ETH' no está disponible en el proveedor 'ripio'"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Corrige bugs de correctness detectados en la auditoría del proyecto:

- **FCI**: deja de usar formato de fecha US (`MM/DD`) y reutiliza `fecha.js` (`YYYY-MM-DD` / `DD/MM/YYYY`, formato argentino).
- **inflación / UVA / riesgo país**: compara fechas por string ISO en lugar de `new Date("YYYY-MM-DD")` (desfase UTC).
- **rendimientos**: el mensaje de error muestra el ticker pedido, no el último del dataset (shadowing de variables).
- **Docs**: FCI, caución (aranceles con `%`) y README (link de tests roto, `fecha.js`).
- **build.js**: orden alfabético de `src/*.js` para builds determinísticos.
- **Tests**: actualiza FCI y agrega unit tests de inflación y rendimientos.

## Test plan
- [x] `npm run build && npm test` — 23 tests green
- [x] FCI con `13/04/2026` apunta a `/2026/04/13/`
- [x] FCI rechaza `04/13/2026` (mes 13 inválido bajo DD/MM)
- [x] `inflacion` fecha anterior / exacta / última sin UTC drift
- [x] `rendimientos("DOGE")` incluye `DOGE` en el mensaje de error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cambia resultados de fórmulas con fechas (FCI pasa a DD/MM; índices sin drift UTC) y el comportamiento ante fechas US en FCI, aunque el alcance es acotado y está cubierto por tests.
> 
> **Overview**
> Corrige bugs de **correctness** en funciones de hoja que consumen series con fecha y en mensajes de error, más documentación y build/tests alineados.
> 
> **FCI** deja el parseo local en formato US (`MM/DD/YYYY`) y pasa a **`fecha.js`** (`YYYY-MM-DD` / **`DD/MM/YYYY`**). Las URLs históricas usan los componentes normalizados; entradas ambiguas tipo `04/13/2026` fallan como fecha inválida. La normalización del tipo de fondo usa `replace` global para acentos (`ó`/`o`).
> 
> **`inflacion`**, **`uva`** y **`riesgopais`** ordenan y filtran por **`localeCompare` en strings ISO** en lugar de `new Date(...)`, evitando desfases UTC al elegir el último valor o la fecha anterior más cercana.
> 
> **`rendimientos`** corrige *shadowing* en bucles para que los errores citen la **moneda/proveedor pedidos**, no el último ítem del dataset.
> 
> **Docs/README**: FCI y caución (aranceles con `%` en Sheets), enlace a `fecha.js`, bloque de desarrollo y tests. **`build.js`** ordena `src/*.js` alfabéticamente para **`all-in-one.js` determinista**. Tests de FCI actualizados y nuevos para inflación y rendimientos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9364d9051b69176da8d1cf9098634cbc798304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->