### PR TITLE
feat: robustez HTTP/cache, paneles unificados y UX

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Ensure all-in-one.js is up to date
+        run: git diff --exit-code all-in-one.js
+      - run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,22 @@ This is a **Google Apps Script library** (not a web app/server). Source files in
 | Action | Command |
 |--------|---------|
 | Install deps | `npm install` |
-| Build | `npm run build` (concatenates `src/*.js` into `all-in-one.js`) |
-| Test | `npm test` (Jest, includes integration tests with 30s timeout) |
+| Build | `npm run build` (concatenates `src/*.js` into `all-in-one.js`, sorted alphabetically) |
+| Test | `npm test` (Jest; unit tests mock UrlFetchApp/CacheService) |
+
+### Architecture notes
+
+- **`src/http.js`**: `fetchJson(url, options)` centralizes HTTP (`muteHttpExceptions`, status check, JSON parse) and optional `CacheService.getScriptCache()` via `cacheKey` / `cacheTtlSeconds`.
+- **`src/market_panel.js`**: shared helpers for data912 live panels (`panelCotizacion`, `panelLista`).
+- **`src/fecha.js`**: shared date parsing (`YYYY-MM-DD` and Argentine `DD/MM/YYYY`).
+- Public custom functions must use `function name()` declarations (Apps Script hoist); avoid assigning helpers to `const`/`var` if other files call them.
+- Cache is best-effort: values may expire early; payloads &gt; ~90KB are not cached.
 
 ### Notes
 
 - **No linter** is configured in this project.
 - **Build before test**: Tests load `all-in-one.js` via `tests/test-wrapper.js`, so you must run `npm run build` before `npm test` whenever source files change.
-- **Integration tests call live APIs** (DolarAPI, ArgentinaDatos, Data912, etc.). These may occasionally fail due to API downtime or rate limiting — this is expected and not a code issue.
+- **Commit `all-in-one.js`** after build so the shipped bundle matches `src/`.
+- **Integration-style caucion tests** do not hit the network; most unit tests mock APIs.
 - **No environment variables or secrets** are required.
 - **No Docker, no database, no backend server** — the only service needed is Node.js with npm.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Forzar recálculo:
 - [src/bcra.js](src/bcra.js) – Código fuente para variables del Banco Central
 - [src/caucion.js](src/caucion.js) – Código fuente para cálculo de cauciones
 - [src/fecha.js](src/fecha.js) – Utilidades compartidas de parseo de fechas (YYYY-MM-DD y DD/MM/YYYY)
+- [src/http.js](src/http.js) – `fetchJson` + cache (`CacheService`) para todas las APIs
+- [src/market_panel.js](src/market_panel.js) – Helpers compartidos de paneles data912
 - [all-in-one.js](all-in-one.js) – Archivo único con todas las funciones combinadas
 
 ## Desarrollo
@@ -90,5 +92,8 @@ npm run build   # genera all-in-one.js a partir de src/
 npm test        # requiere haber corrido build antes
 ```
 
-- Tests unitarios: [tests/](tests/) (`fci.test.js`, `fecha.test.js`, `dolar.test.js`, `all-in-one.test.js`)
+- Tests unitarios: [tests/](tests/)
 - Siempre ejecutar `npm run build` después de modificar archivos en `src/`
+- Las cotizaciones live usan cache de ~60s en Apps Script para ahorrar cuota de UrlFetch
+- Aliases de dólar: `mep` → bolsa, `ccl` → contadoconliqui
+

--- a/all-in-one.js
+++ b/all-in-one.js
@@ -795,11 +795,18 @@ function dolar_historico(tipo, fecha, valor) {
     encodeURIComponent(casa) + '/' +
     componentes.year + '/' + componentes.month + '/' + componentes.day;
 
-  var cotizacion = fetchJson(url, { skipCache: true });
-  if (cotizacion && cotizacion[campo] != null) {
-    return cotizacion[campo];
+  try {
+    var cotizacion = fetchJson(url, { skipCache: true });
+    if (cotizacion && cotizacion[campo] != null) {
+      return cotizacion[campo];
+    }
+    throw new Error("No se encontró cotización para la fecha y tipo especificados");
+  } catch (e) {
+    if (e.message && e.message.indexOf('Error HTTP') === 0) {
+      throw new Error("No se encontró cotización para la fecha y tipo especificados");
+    }
+    throw e;
   }
-  throw new Error("No se encontró cotización para la fecha y tipo especificados");
 }
 
 /**

--- a/all-in-one.js
+++ b/all-in-one.js
@@ -1,5 +1,5 @@
 // Archivo consolidado generado automáticamente
-// Fecha de generación: 2026-07-09T12:35:14.840Z
+// No editar a mano: npm run build
 
 // Namespace para constantes compartidas
 var CONSTANTS = {};

--- a/all-in-one.js
+++ b/all-in-one.js
@@ -1,5 +1,5 @@
 // Archivo consolidado generado automáticamente
-// Fecha de generación: 2026-07-09T12:03:19.736Z
+// Fecha de generación: 2026-07-09T12:28:05.815Z
 
 // Namespace para constantes compartidas
 var CONSTANTS = {};
@@ -10,6 +10,9 @@ CONSTANTS.GASTOS_GARANTIA_TASA_DIARIA = 0.045 / 100 / 90;
 CONSTANTS.IVA_PORCENTAJE = 21 / 100;
 CONSTANTS.ARANCEL_CAUCION_COLOCADORA_TNA = 1.5 / 100;
 CONSTANTS.ARANCEL_CAUCION_TOMADORA_TNA = 4.0 / 100;
+CONSTANTS.HTTP_CACHE_MAX_CHARS = 90000;
+CONSTANTS.HTTP_DEFAULT_TTL = 120;
+CONSTANTS.ATRIBUTOS_PANEL = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
 
 // ================ acciones.js ================
 /**
@@ -23,63 +26,25 @@ CONSTANTS.ARANCEL_CAUCION_TOMADORA_TNA = 4.0 / 100;
  * @customfunction
  */
 function acciones(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de acciones disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_stocks',
+    symbol,
+    value,
+    'acciones',
+    'panel:arg_stocks'
+  );
 }
 
 /**
  * Obtiene la lista completa de acciones que cotizan en el mercado argentino desde la API.
- * 
+ *
  * @return Un arreglo bidimensional con todas las acciones y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function accionesLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada acción como una fila
-  datos.forEach(function(accion) {
-    var fila = columnas.map(function(columna) {
-      return accion[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_stocks', 'panel:arg_stocks');
 }
+
 // ================ bcra.js ================
 /**
  * Devuelve un array con todas las variables disponibles del BCRA (Banco Central de la República Argentina).
@@ -90,20 +55,12 @@ function accionesLista() {
  */
 function bcraVariables() {
   try {
-    // Fetch data from the BCRA API
-    const url = "https://api.bcra.gob.ar/estadisticas/v3.0/Monetarias";
-    const response = UrlFetchApp.fetch(url);
-    const data = JSON.parse(response.getContentText());
-    
-    // Check if the API response is valid
-    if (data.status !== 200 || !data.results || !Array.isArray(data.results)) {
-      throw new Error("Error en la respuesta de la API del BCRA.");
-    }
-    
-    // Return the array of results
-    return data.results.map(item => [item.categoria, item.idVariable, item.descripcion, item.valor, item.fecha]);
+    var data = fetchBcraMonetarias_();
+    return data.results.map(function(item) {
+      return [item.categoria, item.idVariable, item.descripcion, item.valor, item.fecha];
+    });
   } catch (error) {
-    throw new Error(`Error al consultar el BCRA: ${error.message}`);
+    throw new Error("Error al consultar el BCRA: " + error.message);
   }
 }
 
@@ -116,38 +73,45 @@ function bcraVariables() {
  * @customfunction
  */
 function bcra(id) {
-  // Validate input
-  if (!id || isNaN(parseInt(id))) {
+  if (id === undefined || id === null || id === '' || isNaN(parseInt(id, 10))) {
     throw new Error("ID inválido. Debe ser un número válido (1, 4, 5, 6, etc).");
   }
-  
-  // Convert to integer in case it's passed as a string
-  const variableId = parseInt(id);
-  
+
+  var variableId = parseInt(id, 10);
+
   try {
-    // Fetch data from the BCRA API
-    const url = "https://api.bcra.gob.ar/estadisticas/v3.0/Monetarias";
-    const response = UrlFetchApp.fetch(url);
-    const data = JSON.parse(response.getContentText());
-    
-    // Check if the API response is valid
-    if (data.status !== 200 || !data.results || !Array.isArray(data.results)) {
-      throw new Error("Error en la respuesta de la API del BCRA.");
-    }
-    
-    // Find the variable with the specified ID
-    const variable = data.results.find(item => Number(item.idVariable) === variableId);
-    
-    // Return the value if found, otherwise throw an error
+    var data = fetchBcraMonetarias_();
+    var variable = data.results.find(function(item) {
+      return Number(item.idVariable) === variableId;
+    });
+
     if (variable) {
       return variable.valor;
-    } else {
-      throw new Error(`Variable con ID ${variableId} no encontrada. IDs disponibles: ${data.results.map(item => item.idVariable).join(', ')}.`);
     }
+    throw new Error(
+      "Variable con ID " + variableId + " no encontrada. IDs disponibles: " +
+      data.results.map(function(item) { return item.idVariable; }).join(', ') + "."
+    );
   } catch (error) {
-    throw new Error(`Error al consultar el BCRA: ${error.message}`);
+    throw new Error("Error al consultar el BCRA: " + error.message);
   }
 }
+
+/**
+ * @return {{status: number, results: Array}}
+ */
+function fetchBcraMonetarias_() {
+  var data = fetchJson("https://api.bcra.gob.ar/estadisticas/v3.0/Monetarias", {
+    cacheKey: 'api:bcra:monetarias',
+    cacheTtlSeconds: 300
+  });
+
+  if (data.status !== 200 || !data.results || !Array.isArray(data.results)) {
+    throw new Error("Error en la respuesta de la API del BCRA.");
+  }
+  return data;
+}
+
 // ================ bonos.js ================
 /**
  * Obtiene información de bonos que cotizan en el mercado argentino desde la API.
@@ -160,63 +124,25 @@ function bcra(id) {
  * @customfunction
  */
 function bonos(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_bonds';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de bonos disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_bonds',
+    symbol,
+    value,
+    'bonos',
+    'panel:arg_bonds'
+  );
 }
 
 /**
  * Obtiene la lista completa de bonos que cotizan en el mercado argentino desde la API.
- * 
+ *
  * @return {Array} Un arreglo con todos los bonos y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function bonosLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_bonds';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada bono como una fila
-  datos.forEach(function(bono) {
-    var fila = columnas.map(function(columna) {
-      return bono[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_bonds', 'panel:arg_bonds');
 }
+
 // ================ caucion.js ================
 // https://www.byma.com.ar/que-es-byma/derechos-membresias-2/
 // https://www.byma.com.ar/wp-content/uploads/dlm_uploads/2023/10/BYMA-Derechos-Mercado-sobre-Operaciones-2023-10-11.pdf
@@ -461,6 +387,9 @@ function calcularCaucion(
   if (!Number.isInteger(dias)) {
     throw new Error("El parámetro 'dias' debe ser un número entero.");
   }
+  if (dias === 0) {
+    throw new Error("El parámetro 'dias' no puede ser 0. Usar un valor positivo (tomadora) o negativo (colocadora).");
+  }
   if (typeof tna !== "number" || tna < 0) {
     throw new Error("El parámetro 'tna' debe ser un número positivo.");
   }
@@ -528,46 +457,34 @@ function calcularCaucion(
  * @customfunction
  */
 function cedear(symbol, value) {
-  // Normalizo entradas
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
+  }
+  if (value === undefined || value === null || value === '') {
+    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio.");
+  }
+
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos para API de cotizaciones
-  var atributosPermitidosApi = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Valores permitidos para JSON local
+
   var atributosPermitidosJson = ['name', 'ratio'];
-  
-  // Verificar si es un atributo que viene del archivo JSON local
+
   if (atributosPermitidosJson.includes(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
   }
-  
-  // Si no es del JSON local, verificar si es un atributo válido de la API
-  if (!atributosPermitidosApi.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio.");
-  }
-  
-  // Consulta al API para cotizaciones
-  var url = 'https://data912.com/live/arg_cedears';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de CEDEARs disponibles.");
+
+  return panelCotizacion(
+    'https://data912.com/live/arg_cedears',
+    simbolo,
+    atributo,
+    'CEDEARs',
+    'panel:arg_cedears'
+  );
 }
 
 /**
  * Obtiene datos de CEDEARs desde el archivo JSON local.
- * 
+ *
  * @param {string} symbol El símbolo del CEDEAR
  * @param {string} attribute El atributo que se quiere obtener ('name' o 'ratio')
  * @return El valor del atributo solicitado
@@ -578,6 +495,7 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
       if (attribute === 'name') {
         return cedears[i].Name;
       } else if (attribute === 'ratio') {
+        // Se devuelve el string original del JSON ("20" o "1:3"). Ver doc/CEDEAR.md.
         return cedears[i].Ratio;
       }
     }
@@ -595,9 +513,13 @@ function cargarCedearsDesdeDrive() {
 }
 
 function cargarCedearsDesdeGitHub() {
-  var url = 'https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/data/cedears.json';
-  var response = UrlFetchApp.fetch(url);
-  return JSON.parse(response.getContentText());
+  return fetchJson(
+    'https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/data/cedears.json',
+    {
+      cacheKey: 'cedears:json',
+      cacheTtlSeconds: 3600
+    }
+  );
 }
 
 function getCedearDataFromJson(symbol, attribute) {
@@ -622,32 +544,14 @@ function getCedearDataFromJson(symbol, attribute) {
 
 /**
  * Obtiene la lista completa de CEDEARs (Certificados de Depósito Argentinos) desde la API.
- * 
+ *
  * @return Un arreglo bidimensional con todos los CEDEARs y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function cedearLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_cedears';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada CEDEAR como una fila
-  datos.forEach(function(cedear) {
-    var fila = columnas.map(function(columna) {
-      return cedear[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_cedears', 'panel:arg_cedears');
 }
+
 // ================ criptoya.js ================
 /**
  * Obtiene los precios de compra y venta de criptomonedas desde CriptoYa.
@@ -661,125 +565,87 @@ function cedearLista() {
  * @customfunction
  */
 function criptoya(coin, fiat, volumen, exchange, operacion) {
-  // Valores por defecto
+  if (coin === undefined || coin === null || coin === '') {
+    throw new Error("Criptomoneda no proporcionada (ej: 'BTC', 'USDT').");
+  }
+  if (fiat === undefined || fiat === null || fiat === '') {
+    throw new Error("Moneda fiat no proporcionada (ej: 'ARS', 'USD').");
+  }
+
   volumen = volumen || 1;
   operacion = operacion || 'totalCompra';
-  
-  // Normalizo entradas
+
   var cripto = coin.toString().toUpperCase().trim();
   var moneda = fiat.toString().toUpperCase().trim();
   var vol = parseFloat(volumen);
   var tipoOperacion = operacion.toString().toLowerCase().trim();
-  
-  // Mapeo de nombres de operación a los campos de la API
+
   var camposOperacion = {
     'compra': 'ask',
     'totalcompra': 'totalAsk',
     'venta': 'bid',
     'totalventa': 'totalBid'
   };
-  
-  // Verificar si la operación es válida
+
   if (!Object.keys(camposOperacion).includes(tipoOperacion)) {
     throw new Error("Operación inválida: '" + operacion + "'. Operaciones disponibles: compra, totalCompra, venta, totalVenta.");
   }
-  
-  // Campo a consultar en la respuesta
+
   var campo = camposOperacion[tipoOperacion];
-  
-  // URL de la API de CriptoYa
   var url = 'https://criptoya.com/api/' + encodeURIComponent(cripto) + '/' + encodeURIComponent(moneda) + '/' + vol;
-  
+
   try {
-    // Consulta al API
-    var respuesta = UrlFetchApp.fetch(url, {
-      muteHttpExceptions: true,
-      headers: {
-        'Accept': 'application/json'
-      }
+    var datos = fetchJson(url, {
+      headers: { 'Accept': 'application/json' },
+      cacheKey: 'criptoya:' + cripto + ':' + moneda + ':' + vol,
+      cacheTtlSeconds: 60
     });
-    
-    // Comprobar si la respuesta es válida
-    if (respuesta.getResponseCode() !== 200) {
-      var mensajeError = "Código de error: " + respuesta.getResponseCode();
-      try {
-        var error = JSON.parse(respuesta.getContentText());
-        if (error.message) {
-          mensajeError = error.message;
-        }
-      } catch (parseError) {
-        // Mantener mensaje por código HTTP si el cuerpo no es JSON
-      }
-      throw new Error(mensajeError);
-    }
-    
-    // Analizar la respuesta JSON
-    var datos = JSON.parse(respuesta.getContentText());
-    
-    // Si se solicita un exchange específico
+
     if (exchange) {
       var exchangeKey = exchange.toString().toLowerCase().trim();
-      
-      // Verificar si el exchange existe en la respuesta
+
       if (!datos[exchangeKey]) {
         var exchangesDisponibles = Object.keys(datos).join(', ');
         throw new Error("Exchange '" + exchange + "' no disponible. Exchanges disponibles: " + exchangesDisponibles);
       }
-      
-      // Verificar si el campo solicitado existe para ese exchange
+
       if (datos[exchangeKey][campo] === undefined) {
         throw new Error("El campo '" + operacion + "' no está disponible para el exchange '" + exchange + "'");
       }
-      
-      // Devolver el precio del exchange específico
+
       return datos[exchangeKey][campo];
     }
-    
-    // Si no se especifica exchange, buscar el mejor precio según la operación
+
     var mejorPrecio;
-    var mejorExchange;
-    
-    // Determinar el mejor precio según el tipo de operación
     if (tipoOperacion.includes('compra')) {
-      // Para compra, el mejor precio es el más bajo
       mejorPrecio = Infinity;
       for (var ex in datos) {
-        // Verificar que el exchange tenga el campo solicitado
         if (datos[ex][campo] !== undefined && datos[ex][campo] < mejorPrecio) {
           mejorPrecio = datos[ex][campo];
-          mejorExchange = ex;
         }
       }
     } else {
-      // Para venta, el mejor precio es el más alto
       mejorPrecio = -Infinity;
-      for (var ex in datos) {
-        // Verificar que el exchange tenga el campo solicitado
-        if (datos[ex][campo] !== undefined && datos[ex][campo] > mejorPrecio) {
-          mejorPrecio = datos[ex][campo];
-          mejorExchange = ex;
+      for (var ex2 in datos) {
+        if (datos[ex2][campo] !== undefined && datos[ex2][campo] > mejorPrecio) {
+          mejorPrecio = datos[ex2][campo];
         }
       }
     }
-    
-    // Verificar si se encontró algún precio
+
     if (mejorPrecio === Infinity || mejorPrecio === -Infinity) {
       throw new Error("No se encontraron precios disponibles para " + cripto + "/" + moneda + " con el tipo de operación '" + operacion + "'");
     }
-    
-    // Devolver el mejor precio
+
     return mejorPrecio;
-    
   } catch (e) {
-    // Si el error indica que la moneda o criptomoneda no es válida
     if (e.message.includes("Not Found") || e.message.includes("404")) {
       throw new Error("Par " + cripto + "/" + moneda + " no encontrado. Verifica que la cripto y la moneda sean correctas.");
     }
-    
-    // Para otros errores, mostrar el mensaje original
     throw new Error("Error al consultar precio de " + cripto + "/" + moneda + ": " + e.message);
   }
-} 
+}
+
 // ================ crypto.js ================
 /**
  * Obtiene el precio actual de criptomonedas desde la API de Coinbase.
@@ -790,111 +656,108 @@ function criptoya(coin, fiat, volumen, exchange, operacion) {
  * @customfunction
  */
 function crypto(symbol, moneda) {
-  // Valor por defecto
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'BTC').");
+  }
+
   moneda = moneda || 'USD';
-  
-  // Normalizo entradas
+
   var cripto = symbol.toString().toUpperCase().trim();
   var divisa = moneda.toString().toUpperCase().trim();
-  
-  // Par de trading
   var par = cripto + '-' + divisa;
-  
-  // URL de la API de Coinbase (versión pública)
-  var url = 'https://api.coinbase.com/v2/prices/' + par + '/spot';
-  
+  var url = 'https://api.coinbase.com/v2/prices/' + encodeURIComponent(par) + '/spot';
+
   try {
-    // Consulta al API
-    var respuesta = UrlFetchApp.fetch(url, {
-      muteHttpExceptions: true,
-      headers: {
-        'Accept': 'application/json'
-      }
+    var datos = fetchJson(url, {
+      headers: { 'Accept': 'application/json' },
+      cacheKey: 'crypto:' + par,
+      cacheTtlSeconds: 60
     });
-    
-    // Comprobar si la respuesta es válida
-    if (respuesta.getResponseCode() !== 200) {
-      var mensajeError = "Código de error: " + respuesta.getResponseCode();
-      try {
-        var error = JSON.parse(respuesta.getContentText());
-        if (error.errors && error.errors[0] && error.errors[0].message) {
-          mensajeError = error.errors[0].message;
-        }
-      } catch (parseError) {
-        // Mantener mensaje por código HTTP si el cuerpo no es JSON
-      }
-      throw new Error(mensajeError);
-    }
-    
-    // Analizar la respuesta JSON
-    var datos = JSON.parse(respuesta.getContentText());
-    
-    // Verificar si se recibió correctamente la respuesta
+
     if (!datos || !datos.data || !datos.data.amount) {
       throw new Error("Respuesta inválida de Coinbase");
     }
-    
-    // Devolver el precio
+
     return parseFloat(datos.data.amount);
-    
   } catch (e) {
-    // Si el error indica que no se encontró el par de trading
     if (e.message.includes("Not Found") || e.message.includes("404")) {
       throw new Error("Par de trading no encontrado: '" + par + "'. Verifica que el símbolo y la moneda sean correctos.");
     }
-    
-    // Para otros errores, mostrar el mensaje original
     throw new Error("Error al consultar el precio de " + cripto + ": " + e.message);
   }
-} 
+}
+
 // ================ dolar.js ================
 /**
  * Obtiene la cotización de los distintos tipos de dólar en Argentina.
  *
- * @param {string} tipo La “casa” del dólar: oficial, blue, bolsa, contadoconliqui, mayorista, cripto o tarjeta.
- * @param {string} operacion 'compra', 'venta' o 'promedio'.
+ * @param {string} tipo La “casa” del dólar: oficial, blue, bolsa/mep, contadoconliqui/ccl, mayorista, cripto o tarjeta.
+ * @param {string} operacion 'compra', 'venta' o 'promedio'. Por defecto: 'venta'.
  * @return El valor numérico de la operación solicitada.
  * @customfunction
  */
 function dolar(tipo, operacion) {
-  // Consulta al API
-  var url = 'https://dolarapi.com/v1/dolares';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var casa = tipo.toString().toLowerCase().trim();
+  if (tipo === undefined || tipo === null || tipo === '') {
+    throw new Error("Tipo no proporcionado. Usa 'blue', 'oficial', 'mep', 'ccl', etc.");
+  }
+
+  operacion = (operacion === undefined || operacion === null || operacion === '')
+    ? 'venta'
+    : operacion;
+
+  var casa = normalizarCasaDolar_(tipo);
   var op = operacion.toString().toLowerCase().trim();
-  
-  // Busco la casa solicitada
+
+  var datos = fetchJson('https://dolarapi.com/v1/dolares', {
+    cacheKey: 'api:dolarapi:dolares',
+    cacheTtlSeconds: 60
+  });
+
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].casa.toLowerCase() === casa) {
       var compra = datos[i].compra;
-      var venta  = datos[i].venta;
-      
-      if (op === 'compra')     return compra;
-      if (op === 'venta')      return venta;
+      var venta = datos[i].venta;
+
+      if (op === 'compra') return compra;
+      if (op === 'venta') return venta;
       if (op === 'promedio') {
         if (compra != null && venta != null) return (compra + venta) / 2;
         if (compra != null) return compra;
         if (venta != null) return venta;
         throw new Error("No hay cotización disponible para calcular el promedio de '" + tipo + "'.");
       }
-      
+
       throw new Error("Operación inválida: '" + operacion + "'. Usa 'compra', 'venta' o 'promedio'.");
     }
   }
-  
-  // Si no encontró la casa
-  var disponibles = datos.map(function(o){ return o.casa; }).join(', ');
-  throw new Error("Tipo inválido: '" + tipo + "'. Tipos disponibles: " + disponibles + ".");
+
+  var disponibles = datos.map(function(o) { return o.casa; }).join(', ');
+  throw new Error("Tipo inválido: '" + tipo + "'. Tipos disponibles: " + disponibles + " (aliases: mep→bolsa, ccl→contadoconliqui).");
+}
+
+/**
+ * Normaliza aliases comunes de casas de dólar.
+ *
+ * @param {*} tipo
+ * @return {string}
+ */
+function normalizarCasaDolar_(tipo) {
+  var casa = tipo.toString().toLowerCase().trim().replace(/\s+/g, '');
+
+  if (casa === 'mep' || casa === 'bolsa') {
+    return 'bolsa';
+  }
+  if (casa === 'ccl' || casa === 'contado' || casa === 'contadoconliqui' || casa === 'contadoconliquidacion') {
+    return 'contadoconliqui';
+  }
+  return casa;
 }
 
 // ================ dolar_historico.js ================
 /**
  * Obtiene la cotización histórica del dólar según el tipo y fecha especificados
- * 
- * @param {string} tipo - Tipo de dólar (blue, oficial, mayorista, etc.)
+ *
+ * @param {string} tipo - Tipo de dólar (blue, oficial, mayorista, mep, ccl, etc.)
  * @param {string} fecha - Fecha en formato YYYY-MM-DD o DD/MM/YYYY
  * @param {string} valor - Opcional: "compra" o "venta" (por defecto es "venta")
  * @return {number} Valor de la cotización para el tipo y fecha solicitados
@@ -903,77 +766,86 @@ function dolar(tipo, operacion) {
 function dolar_historico(tipo, fecha, valor) {
   valor = valor || "venta";
 
-  // URL de la API de ArgentinaDatos para cotizaciones de dólares
-  const url = 'https://api.argentinadatos.com/v1/cotizaciones/dolares';
-
   if (!tipo) {
     throw new Error("Debe especificar un tipo de dólar");
   }
 
+  var casa = normalizarCasaDolar_(tipo);
+
   // Si no se proporciona fecha, usar la fecha actual en Argentina
+  var fechaISO;
   if (!fecha) {
-    const hoy = new Date();
-    fecha = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
+    var hoy = new Date();
+    fechaISO = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
   } else {
     try {
-      fecha = formatearFechaISO(fecha);
+      fechaISO = formatearFechaISO(fecha);
     } catch (e) {
       throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
     }
   }
 
-  if (valor.toLowerCase() !== "compra" && valor.toLowerCase() !== "venta") {
+  var campo = valor.toString().toLowerCase().trim();
+  if (campo !== "compra" && campo !== "venta") {
     throw new Error("El valor debe ser 'compra' o 'venta'");
   }
 
-  const response = UrlFetchApp.fetch(url);
-  const data = JSON.parse(response.getContentText());
+  var componentes = obtenerComponentesFecha(fechaISO);
+  var url = 'https://api.argentinadatos.com/v1/cotizaciones/dolares/' +
+    encodeURIComponent(casa) + '/' +
+    componentes.year + '/' + componentes.month + '/' + componentes.day;
 
-  const cotizacion = data.filter(item =>
-    item.casa.toLowerCase() === tipo.toLowerCase() &&
-    item.fecha === fecha
-  );
-
-  if (cotizacion.length > 0) {
-    return cotizacion[0][valor.toLowerCase()];
+  try {
+    var cotizacion = fetchJson(url, { skipCache: true });
+    if (cotizacion && cotizacion[campo] != null) {
+      return cotizacion[campo];
+    }
+    throw new Error("No se encontró cotización para la fecha y tipo especificados");
+  } catch (e) {
+    if (e.message && e.message.indexOf('Error HTTP') === 0) {
+      throw new Error("No se encontró cotización para la fecha y tipo especificados");
+    }
+    throw e;
   }
-
-  throw new Error("No se encontró cotización para la fecha y tipo especificados");
 }
 
 /**
  * Obtiene todas las cotizaciones de dólar para una fecha específica
- * 
+ *
  * @param {string} fecha - Fecha en formato YYYY-MM-DD o DD/MM/YYYY
  * @return {Array} Matriz con las cotizaciones de cada tipo de dólar para la fecha
  * @customfunction
  */
 function dolar_historico_todos(fecha) {
-  const url = 'https://api.argentinadatos.com/v1/cotizaciones/dolares';
-
+  var fechaISO;
   if (!fecha) {
-    const hoy = new Date();
-    fecha = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
+    var hoy = new Date();
+    fechaISO = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
   } else {
     try {
-      fecha = formatearFechaISO(fecha);
+      fechaISO = formatearFechaISO(fecha);
     } catch (e) {
       throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
     }
   }
 
-  const response = UrlFetchApp.fetch(url);
-  const data = JSON.parse(response.getContentText());
+  // Serie completa cacheada (payload grande: solo cachear si entra en el límite de CacheService)
+  var data = fetchJson('https://api.argentinadatos.com/v1/cotizaciones/dolares', {
+    cacheKey: 'api:ad:dolares:all',
+    cacheTtlSeconds: 300
+  });
 
-  const cotizaciones = data.filter(item => item.fecha === fecha);
+  var cotizaciones = data.filter(function(item) {
+    return item.fecha === fechaISO;
+  });
 
   if (cotizaciones.length === 0) {
     throw new Error("No se encontraron cotizaciones para la fecha especificada");
   }
 
-  const resultado = [["Tipo", "Compra", "Venta", "Fecha"]];
+  var resultado = [["Tipo", "Compra", "Venta", "Fecha"]];
 
-  cotizaciones.forEach(cotizacion => {
+  cotizaciones.forEach(function(cotizacion) {
     resultado.push([
       cotizacion.casa,
       cotizacion.compra,
@@ -997,19 +869,16 @@ function dolar_historico_todos(fecha) {
  * @customfunction
  */
 function fci(tipoFondo, nombreFondo, fecha, campo) {
-  // Normalizo entradas
   var tipo = tipoFondo ? tipoFondo.toString().toLowerCase().trim() : '';
   var nombre = nombreFondo ? nombreFondo.toString().trim() : '';
   var campoDatos = campo ? campo.toString().toLowerCase().trim() : 'vcp';
 
-  // Validar tipo de fondo (normalización con replace global)
   var tipoNormalizado = tipo.replace(/\s+/g, '').replace(/[óo]/g, 'o');
   var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta', 'retornototal'];
   if (!tiposPermitidos.includes(tipoNormalizado)) {
     throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta, retornoTotal.");
   }
 
-  // Convertir tipo a formato de API
   var tipoAPI = tipoNormalizado;
   switch (tipoAPI) {
     case 'mercadodinero': tipoAPI = 'mercadoDinero'; break;
@@ -1019,19 +888,17 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     case 'retornototal': tipoAPI = 'retornoTotal'; break;
   }
 
-  // Validar el campo a consultar
   var camposPermitidos = ['vcp', 'ccp', 'patrimonio'];
   if (!camposPermitidos.includes(campoDatos)) {
     throw new Error("Campo inválido. Campos permitidos: vcp (valor cuotaparte), ccp (cantidad cuotapartes), patrimonio.");
   }
 
-  // Validar que se haya proporcionado un nombre de fondo
   if (!nombre) {
     throw new Error("Debe especificar un nombre de fondo.");
   }
 
-  // Construir URL según si se proporciona fecha o no
   var url;
+  var cacheKey = null;
   if (fecha) {
     try {
       var componentesFecha = obtenerComponentesFecha(fecha);
@@ -1041,20 +908,14 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     }
   } else {
     url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/ultimo';
+    cacheKey = 'api:ad:fci:' + tipoAPI + ':ultimo';
   }
 
   try {
-    // Consulta al API
-    var respuesta = UrlFetchApp.fetch(url, {
-      muteHttpExceptions: true
-    });
-
-    // Verificar si la respuesta es válida
-    if (respuesta.getResponseCode() !== 200) {
-      throw new Error("Error al consultar la API: Código " + respuesta.getResponseCode() + ". Verifique los parámetros.");
-    }
-
-    var datos = JSON.parse(respuesta.getContentText());
+    var datos = fetchJson(url, cacheKey ? {
+      cacheKey: cacheKey,
+      cacheTtlSeconds: 120
+    } : { skipCache: true });
 
     function esFondoValido(item) {
       return item.fondo && !item.fondo.startsWith("Region:") &&
@@ -1071,45 +932,54 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
       return valor;
     }
 
-    // Buscar el fondo por nombre (exacto primero, luego parcial sin ambigüedad)
+    var nombreLower = nombre.toLowerCase();
     var coincidenciasExactas = [];
+    var coincidenciasExactasCI = [];
     var coincidenciasParciales = [];
+    var coincidenciasParcialesCI = [];
+
     for (var i = 0; i < datos.length; i++) {
       if (!esFondoValido(datos[i])) continue;
-      if (datos[i].fondo === nombre) {
+      var fondoNombre = datos[i].fondo;
+      var fondoLower = fondoNombre.toLowerCase();
+
+      if (fondoNombre === nombre) {
         coincidenciasExactas.push(datos[i]);
-      } else if (datos[i].fondo.includes(nombre)) {
+      } else if (fondoLower === nombreLower) {
+        coincidenciasExactasCI.push(datos[i]);
+      } else if (fondoNombre.includes(nombre)) {
         coincidenciasParciales.push(datos[i]);
+      } else if (fondoLower.includes(nombreLower)) {
+        coincidenciasParcialesCI.push(datos[i]);
       }
     }
 
-    if (coincidenciasExactas.length === 1) {
-      return valorCampoFondo(coincidenciasExactas[0]);
-    }
-    if (coincidenciasExactas.length > 1) {
-      throw new Error("Varios fondos coinciden con '" + nombre + "': " + coincidenciasExactas.map(function(f) { return f.fondo; }).join(', ') + ".");
-    }
-    if (coincidenciasParciales.length === 1) {
-      return valorCampoFondo(coincidenciasParciales[0]);
-    }
-    if (coincidenciasParciales.length > 1) {
-      throw new Error("Varios fondos coinciden con '" + nombre + "': " + coincidenciasParciales.slice(0, 10).map(function(f) { return f.fondo; }).join(', ') + "...");
+    function resolverCoincidencias(lista) {
+      if (lista.length === 1) return valorCampoFondo(lista[0]);
+      if (lista.length > 1) {
+        throw new Error("Varios fondos coinciden con '" + nombre + "': " + lista.slice(0, 10).map(function(f) { return f.fondo; }).join(', ') + (lista.length > 10 ? "..." : "."));
+      }
+      return null;
     }
 
-    // Si no se encontró el fondo, mostrar algunos disponibles
+    var r = resolverCoincidencias(coincidenciasExactas);
+    if (r !== null) return r;
+    r = resolverCoincidencias(coincidenciasExactasCI);
+    if (r !== null) return r;
+    r = resolverCoincidencias(coincidenciasParciales);
+    if (r !== null) return r;
+    r = resolverCoincidencias(coincidenciasParcialesCI);
+    if (r !== null) return r;
+
     var fondosDisponibles = datos
-      .filter(function(d) {
-        return esFondoValido(d);
-      })
-      .map(function(d) {
-        return d.fondo;
-      })
+      .filter(esFondoValido)
+      .map(function(d) { return d.fondo; })
       .slice(0, 10)
       .join(", ") + "...";
 
     throw new Error("Fondo '" + nombre + "' no encontrado para el tipo '" + tipoFondo + "'. Algunos fondos disponibles: " + fondosDisponibles);
   } catch (e) {
-    if (e.message.includes("Error al consultar la API")) {
+    if (e.message.includes("Error HTTP") || e.message.includes("Error al consultar")) {
       throw e;
     }
     throw new Error("Error al consultar información de '" + tipoFondo + "': " + e.message);
@@ -1123,56 +993,42 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
  * @customfunction
  */
 function fciLista() {
-  // Tipos de fondos a consultar
   var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta', 'retornoTotal'];
-
-  // Matriz para almacenar todos los fondos
   var todosLosFondos = [['Nombre del Fondo', 'Tipo de Fondo', 'Valor Cuotaparte']];
 
-  // Recorrer cada tipo de fondo
   tipos.forEach(function(tipo) {
     try {
-      // Construir URL para obtener la lista de fondos
       var url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipo + '/ultimo';
-
-      // Consultar la API
-      var respuesta = UrlFetchApp.fetch(url, {
-        muteHttpExceptions: true
+      var datos = fetchJson(url, {
+        cacheKey: 'api:ad:fci:' + tipo + ':ultimo',
+        cacheTtlSeconds: 120
       });
 
-      // Verificar si la respuesta es válida
-      if (respuesta.getResponseCode() === 200) {
-        var datos = JSON.parse(respuesta.getContentText());
+      var fondosValidos = datos.filter(function(d) {
+        return d.fondo &&
+               !d.fondo.startsWith("Region:") &&
+               !d.fondo.startsWith("Duration:") &&
+               !d.fondo.startsWith("Benchmark:") &&
+               !d.fondo.startsWith("Moneda:");
+      });
 
-        // Filtrar solo los fondos válidos (no categorías)
-        var fondosValidos = datos.filter(function(d) {
-          return d.fondo &&
-                 !d.fondo.startsWith("Region:") &&
-                 !d.fondo.startsWith("Duration:") &&
-                 !d.fondo.startsWith("Benchmark:") &&
-                 !d.fondo.startsWith("Moneda:");
-        });
+      fondosValidos.forEach(function(fondo) {
+        var nombreFormateado = tipo;
+        switch (tipo) {
+          case 'mercadoDinero': nombreFormateado = 'Mercado de Dinero'; break;
+          case 'rentaVariable': nombreFormateado = 'Renta Variable'; break;
+          case 'rentaFija': nombreFormateado = 'Renta Fija'; break;
+          case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
+          case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
+        }
 
-        // Agregar cada fondo a la matriz de resultados
-        fondosValidos.forEach(function(fondo) {
-          var nombreFormateado = tipo;
-          switch (tipo) {
-            case 'mercadoDinero': nombreFormateado = 'Mercado de Dinero'; break;
-            case 'rentaVariable': nombreFormateado = 'Renta Variable'; break;
-            case 'rentaFija': nombreFormateado = 'Renta Fija'; break;
-            case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
-            case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
-          }
-
-          todosLosFondos.push([
-            fondo.fondo,
-            nombreFormateado,
-            fondo.vcp
-          ]);
-        });
-      }
+        todosLosFondos.push([
+          fondo.fondo,
+          nombreFormateado,
+          fondo.vcp
+        ]);
+      });
     } catch (e) {
-      // Si hay un error con un tipo de fondo, continuar con los demás
       Logger.log("Error al consultar fondos de tipo '" + tipo + "': " + e.message);
     }
   });
@@ -1273,6 +1129,143 @@ function parsearFechaLocal(fechaInput) {
   );
 }
 
+// ================ http.js ================
+/**
+ * Helpers HTTP + cache para Google Apps Script.
+ * Usa CacheService.getScriptCache() cuando está disponible.
+ * Los valores de cache no están garantizados; siempre se puede re-fetchear.
+ */
+
+// Constante CONSTANTS.HTTP_CACHE_MAX_CHARS movida al namespace CONSTANTS
+// var HTTP_CACHE_MAX_CHARS = 90000; // margen bajo el límite ~100KB de CacheService
+// Constante CONSTANTS.HTTP_DEFAULT_TTL movida al namespace CONSTANTS
+// var HTTP_DEFAULT_TTL = 120;
+
+/**
+ * Lee un valor del script cache. Devuelve null si no hay cache, falla o no hay key.
+ *
+ * @param {string} key
+ * @return {string|null}
+ */
+function cacheGet_(key) {
+  if (!key) return null;
+  try {
+    if (typeof CacheService === 'undefined' || !CacheService.getScriptCache) {
+      return null;
+    }
+    var cache = CacheService.getScriptCache();
+    if (!cache) return null;
+    return cache.get(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Guarda un valor en el script cache. Ignora fallos y payloads grandes.
+ *
+ * @param {string} key
+ * @param {string} value
+ * @param {number} ttlSeconds
+ */
+function cachePut_(key, value, ttlSeconds) {
+  if (!key || value == null) return;
+  if (value.length > CONSTANTS.HTTP_CACHE_MAX_CHARS) return;
+  try {
+    if (typeof CacheService === 'undefined' || !CacheService.getScriptCache) {
+      return;
+    }
+    var cache = CacheService.getScriptCache();
+    if (!cache) return;
+    var ttl = ttlSeconds || CONSTANTS.HTTP_DEFAULT_TTL;
+    if (ttl < 1) ttl = 1;
+    if (ttl > 21600) ttl = 21600;
+    cache.put(key, value, ttl);
+  } catch (e) {
+    // Cache es best-effort
+  }
+}
+
+/**
+ * Fetch JSON con muteHttpExceptions, validación de status y cache opcional.
+ *
+ * @param {string} url
+ * @param {Object} [options]
+ * @param {Object} [options.headers] Headers HTTP adicionales
+ * @param {string} [options.cacheKey] Clave de CacheService
+ * @param {number} [options.cacheTtlSeconds] TTL en segundos (default 120)
+ * @param {boolean} [options.skipCache] Si true, no lee ni escribe cache
+ * @return {*} JSON parseado
+ */
+function fetchJson(url, options) {
+  options = options || {};
+  var cacheKey = options.cacheKey;
+  var skipCache = options.skipCache === true;
+  var ttl = options.cacheTtlSeconds != null ? options.cacheTtlSeconds : CONSTANTS.HTTP_DEFAULT_TTL;
+
+  if (!skipCache && cacheKey) {
+    var cached = cacheGet_(cacheKey);
+    if (cached != null) {
+      try {
+        return JSON.parse(cached);
+      } catch (parseCacheError) {
+        // Cache corrupto: seguir con fetch
+      }
+    }
+  }
+
+  var fetchOptions = {
+    muteHttpExceptions: true,
+    headers: options.headers || {}
+  };
+
+  var respuesta;
+  try {
+    respuesta = UrlFetchApp.fetch(url, fetchOptions);
+  } catch (fetchError) {
+    throw new Error("Error de red al consultar la API: " + fetchError.message);
+  }
+
+  var code = respuesta.getResponseCode();
+  var text = respuesta.getContentText();
+
+  if (code < 200 || code >= 300) {
+    var detalle = text;
+    try {
+      var errBody = JSON.parse(text);
+      if (errBody && errBody.message) {
+        detalle = errBody.message;
+      } else if (errBody && errBody.error) {
+        detalle = errBody.error;
+      } else if (errBody && errBody.errors && errBody.errors[0] && errBody.errors[0].message) {
+        detalle = errBody.errors[0].message;
+      }
+    } catch (e) {
+      if (detalle && detalle.length > 200) {
+        detalle = detalle.substring(0, 200) + "...";
+      }
+    }
+    throw new Error("Error HTTP " + code + " al consultar la API: " + detalle);
+  }
+
+  var datos;
+  try {
+    datos = JSON.parse(text);
+  } catch (parseError) {
+    throw new Error("Respuesta inválida (no JSON) de la API.");
+  }
+
+  if (!skipCache && cacheKey) {
+    try {
+      cachePut_(cacheKey, text, ttl);
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  return datos;
+}
+
 // ================ inflacion.js ================
 /**
  * Obtiene los índices de inflación de Argentina.
@@ -1282,22 +1275,19 @@ function parsearFechaLocal(fechaInput) {
  * @customfunction
  */
 function inflacion(fecha) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/indices/inflacion';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/indices/inflacion', {
+    cacheKey: 'api:ad:inflacion',
+    cacheTtlSeconds: 300
+  });
 
   if (!datos || !datos.length) {
     throw new Error("No se recibieron datos de inflación desde la API.");
   }
 
-  // Si no se proporciona fecha, devolver el valor más reciente
-  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return datos[0].valor;
   }
 
@@ -1308,14 +1298,12 @@ function inflacion(fecha) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
 
-  // Buscar la fecha exacta
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].fecha === fechaFormateada) {
       return datos[i].valor;
     }
   }
 
-  // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
     return d.fecha <= fechaFormateada;
   });
@@ -1324,11 +1312,9 @@ function inflacion(fecha) {
     fechasMenores.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return fechasMenores[0].valor;
   }
 
-  // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
     return a.fecha.localeCompare(b.fecha);
   });
@@ -1346,77 +1332,108 @@ function inflacion(fecha) {
  * @customfunction
  */
 function letras(symbol, valor) {
-  // Validate inputs
-  if (!symbol) {
-    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: BB2Y5, BNA6D, etc).");
-  }
-  
-  if (!valor) {
-    throw new Error("Valor no proporcionado. Valores disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Standardize symbol and value
-  symbol = symbol.toUpperCase().trim();
-  valor = valor.toLowerCase().trim();
-  
-  // Validate valor parameter
-  const validValues = ["c", "v", "q_bid", "px_bid", "px_ask", "q_ask", "q_op", "pct_change"];
-  if (!validValues.includes(valor)) {
-    throw new Error(`Atributo inválido: '${valor}'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.`);
-  }
-  
-  try {
-    // Fetch data from the API
-    const url = "https://data912.com/live/arg_notes";
-    const response = UrlFetchApp.fetch(url);
-    const letrasList = JSON.parse(response.getContentText());
-    
-    // Find the requested treasury bill
-    const letra = letrasList.find(letra => letra.symbol === symbol);
-    
-    // Return the value if found, otherwise throw an error
-    if (letra) {
-      return letra[valor];
-    } else {
-      throw new Error(`Símbolo inválido: '${symbol}'. No se encontró en la lista de letras disponibles.`);
-    }
-  } catch (error) {
-    throw new Error(`Error al consultar datos de letras: ${error.message}`);
-  }
+  return panelCotizacion(
+    'https://data912.com/live/arg_notes',
+    symbol,
+    valor,
+    'letras',
+    'panel:arg_notes'
+  );
 }
 
 /**
  * Obtiene la lista completa de letras del tesoro desde la API.
- * 
+ *
  * @return Un arreglo bidimensional con todas las letras y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function letrasLista() {
-  try {
-    // Fetch data from the API
-    const url = "https://data912.com/live/arg_notes";
-    const response = UrlFetchApp.fetch(url);
-    const datos = JSON.parse(response.getContentText());
-    
-    // Definir las columnas que queremos mostrar
-    const columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-    
-    // Crear el arreglo bidimensional comenzando con los encabezados
-    const resultado = [columnas];
-    
-    // Agregar cada letra como una fila
-    datos.forEach(function(letra) {
-      const fila = columnas.map(function(columna) {
-        return letra[columna];
-      });
-      resultado.push(fila);
-    });
-    
-    return resultado;
-  } catch (error) {
-    throw new Error(`Error al consultar datos de letras: ${error.message}`);
-  }
+  return panelLista('https://data912.com/live/arg_notes', 'panel:arg_notes');
 }
+
+// ================ market_panel.js ================
+/**
+ * Helpers compartidos para paneles live de data912 (acciones, bonos, etc.).
+ */
+
+// Constante CONSTANTS.ATRIBUTOS_PANEL movida al namespace CONSTANTS
+// var ATRIBUTOS_PANEL = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
+
+/**
+ * Cotización de un símbolo en un panel live.
+ *
+ * @param {string} url URL del panel
+ * @param {*} symbol Símbolo del instrumento
+ * @param {*} value Atributo a devolver
+ * @param {string} nombreMercado Nombre para mensajes de error (ej: 'acciones')
+ * @param {string} cacheKey Clave de cache del panel
+ * @return {*} Valor del atributo
+ */
+function panelCotizacion(url, symbol, value, nombreMercado, cacheKey) {
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido.");
+  }
+  if (value === undefined || value === null || value === '') {
+    throw new Error("Atributo no proporcionado. Atributos disponibles: " + CONSTANTS.ATRIBUTOS_PANEL.join(', ') + ".");
+  }
+
+  var simbolo = symbol.toString().toUpperCase().trim();
+  var atributo = value.toString().toLowerCase().trim();
+
+  if (!CONSTANTS.ATRIBUTOS_PANEL.includes(atributo)) {
+    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: " + CONSTANTS.ATRIBUTOS_PANEL.join(', ') + ".");
+  }
+
+  var datos = fetchJson(url, {
+    cacheKey: cacheKey,
+    cacheTtlSeconds: 60
+  });
+
+  if (!datos || !datos.length) {
+    throw new Error("No se recibieron datos del panel de " + nombreMercado + ".");
+  }
+
+  for (var i = 0; i < datos.length; i++) {
+    if (datos[i].symbol === simbolo) {
+      return datos[i][atributo];
+    }
+  }
+
+  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de " + nombreMercado + " disponibles.");
+}
+
+/**
+ * Lista completa de un panel live como matriz (headers + filas).
+ *
+ * @param {string} url URL del panel
+ * @param {string} cacheKey Clave de cache del panel
+ * @return {Array}
+ */
+function panelLista(url, cacheKey) {
+  var datos = fetchJson(url, {
+    cacheKey: cacheKey,
+    cacheTtlSeconds: 60
+  });
+
+  if (!datos || !datos.length) {
+    throw new Error("No se recibieron datos del panel.");
+  }
+
+  var columnas = CONSTANTS.ATRIBUTOS_PANEL.slice();
+  columnas.unshift('symbol');
+
+  var resultado = [columnas];
+  for (var i = 0; i < datos.length; i++) {
+    var item = datos[i];
+    var fila = [];
+    for (var j = 0; j < columnas.length; j++) {
+      fila.push(item[columnas[j]]);
+    }
+    resultado.push(fila);
+  }
+  return resultado;
+}
+
 // ================ obligaciones.js ================
 /**
  * Obtiene información de obligaciones negociables que cotizan en el mercado argentino desde la API.
@@ -1429,63 +1446,25 @@ function letrasLista() {
  * @customfunction
  */
 function obligaciones(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_corp';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de obligaciones negociables disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_corp',
+    symbol,
+    value,
+    'obligaciones negociables',
+    'panel:arg_corp'
+  );
 }
 
 /**
  * Obtiene la lista completa de obligaciones negociables que cotizan en el mercado argentino desde la API.
- * 
+ *
  * @return {Array} Un arreglo con todas las obligaciones negociables y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function obligacionesLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_corp';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada obligación negociable como una fila
-  datos.forEach(function(obligacion) {
-    var fila = columnas.map(function(columna) {
-      return obligacion[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
-} 
+  return panelLista('https://data912.com/live/arg_corp', 'panel:arg_corp');
+}
+
 // ================ opciones.js ================
 /**
  * Obtiene información de opciones (calls y puts) que cotizan en el mercado argentino.
@@ -1498,62 +1477,25 @@ function obligacionesLista() {
  * @customfunction
  */
 function opciones(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_options';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  throw new Error("Símbolo de opción inválido: '" + symbol + "'. No se encontró en la lista de opciones disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_options',
+    symbol,
+    value,
+    'opciones',
+    'panel:arg_options'
+  );
 }
 
 /**
  * Obtiene la lista completa de opciones (calls y puts) que cotizan en el mercado argentino.
- * 
+ *
  * @return Un arreglo bidimensional con todas las opciones y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function opcionesLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_options';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada opción como una fila
-  datos.forEach(function(opcion) {
-    var fila = columnas.map(function(columna) {
-      return opcion[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_options', 'panel:arg_options');
 }
+
 // ================ plazofijo.js ================
 /**
  * Obtiene las tasas de plazos fijos ofrecidas por bancos en Argentina.
@@ -1564,11 +1506,11 @@ function opcionesLista() {
  * @customfunction
  */
 function plazofijo(banco, tipoCliente) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/tasas/plazoFijo';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/tasas/plazoFijo', {
+    cacheKey: 'api:ad:plazofijo',
+    cacheTtlSeconds: 120
+  });
+
   // Normalizo entradas
   var nombreBanco = banco ? banco.toString().toUpperCase().trim() : '';
   var tipo = tipoCliente ? tipoCliente.toString().toLowerCase().trim() : 'cliente';
@@ -1668,10 +1610,10 @@ function plazofijo(banco, tipoCliente) {
  * @customfunction
  */
 function rendimientos(moneda, proveedor) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/rendimientos';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/rendimientos', {
+    cacheKey: 'api:ad:rendimientos',
+    cacheTtlSeconds: 120
+  });
 
   // Normalizo entradas
   var crypto = moneda ? moneda.toString().toUpperCase().trim() : '';
@@ -1772,22 +1714,19 @@ function rendimientos(moneda, proveedor) {
  * @customfunction
  */
 function riesgopais(fecha) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/indices/riesgo-pais';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/indices/riesgo-pais', {
+    cacheKey: 'api:ad:riesgo-pais',
+    cacheTtlSeconds: 300
+  });
 
   if (!datos || !datos.length) {
     throw new Error("No se recibieron datos de riesgo país desde la API.");
   }
 
-  // Si no se proporciona fecha, devolver el valor más reciente
-  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return datos[0].valor;
   }
 
@@ -1798,14 +1737,12 @@ function riesgopais(fecha) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
 
-  // Buscar la fecha exacta
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].fecha === fechaFormateada) {
       return datos[i].valor;
     }
   }
 
-  // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
     return d.fecha <= fechaFormateada;
   });
@@ -1814,11 +1751,9 @@ function riesgopais(fecha) {
     fechasMenores.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return fechasMenores[0].valor;
   }
 
-  // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
     return a.fecha.localeCompare(b.fecha);
   });
@@ -1838,62 +1773,25 @@ function riesgopais(fecha) {
  * @customfunction
  */
 function usa_stocks(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/usa_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de acciones estadounidenses disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/usa_stocks',
+    symbol,
+    value,
+    'acciones estadounidenses',
+    'panel:usa_stocks'
+  );
 }
 
 /**
  * Obtiene la lista completa de acciones de Estados Unidos desde la API.
- * 
- * @return Un arreglo bidimensional con todas las acciones estadounidenses y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
+ *
+ * @return Un arreglo bidimensional con todas las acciones y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function usa_stocksLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/usa_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada acción como una fila
-  datos.forEach(function(usaStock) {
-    var fila = columnas.map(function(columna) {
-      return usaStock[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/usa_stocks', 'panel:usa_stocks');
 }
+
 // ================ uva.js ================
 /**
  * Obtiene los índices UVA (Unidad de Valor Adquisitivo) de Argentina.
@@ -1903,22 +1801,19 @@ function usa_stocksLista() {
  * @customfunction
  */
 function uva(fecha) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/indices/uva';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/indices/uva', {
+    cacheKey: 'api:ad:uva',
+    cacheTtlSeconds: 300
+  });
 
   if (!datos || !datos.length) {
     throw new Error("No se recibieron datos de UVA desde la API.");
   }
 
-  // Si no se proporciona fecha, devolver el valor más reciente
-  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return datos[0].valor;
   }
 
@@ -1929,14 +1824,12 @@ function uva(fecha) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
 
-  // Buscar la fecha exacta
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].fecha === fechaFormateada) {
       return datos[i].valor;
     }
   }
 
-  // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
     return d.fecha <= fechaFormateada;
   });
@@ -1945,11 +1838,9 @@ function uva(fecha) {
     fechasMenores.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return fechasMenores[0].valor;
   }
 
-  // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
     return a.fecha.localeCompare(b.fecha);
   });

--- a/all-in-one.js
+++ b/all-in-one.js
@@ -1,5 +1,5 @@
 // Archivo consolidado generado automáticamente
-// Fecha de generación: 2026-07-09T12:28:05.815Z
+// Fecha de generación: 2026-07-09T12:35:14.840Z
 
 // Namespace para constantes compartidas
 var CONSTANTS = {};
@@ -795,18 +795,11 @@ function dolar_historico(tipo, fecha, valor) {
     encodeURIComponent(casa) + '/' +
     componentes.year + '/' + componentes.month + '/' + componentes.day;
 
-  try {
-    var cotizacion = fetchJson(url, { skipCache: true });
-    if (cotizacion && cotizacion[campo] != null) {
-      return cotizacion[campo];
-    }
-    throw new Error("No se encontró cotización para la fecha y tipo especificados");
-  } catch (e) {
-    if (e.message && e.message.indexOf('Error HTTP') === 0) {
-      throw new Error("No se encontró cotización para la fecha y tipo especificados");
-    }
-    throw e;
+  var cotizacion = fetchJson(url, { skipCache: true });
+  if (cotizacion && cotizacion[campo] != null) {
+    return cotizacion[campo];
   }
+  throw new Error("No se encontró cotización para la fecha y tipo especificados");
 }
 
 /**
@@ -1415,14 +1408,13 @@ function panelLista(url, cacheKey) {
     cacheTtlSeconds: 60
   });
 
-  if (!datos || !datos.length) {
-    throw new Error("No se recibieron datos del panel.");
-  }
-
   var columnas = CONSTANTS.ATRIBUTOS_PANEL.slice();
   columnas.unshift('symbol');
 
   var resultado = [columnas];
+  if (!datos || !datos.length) {
+    return resultado;
+  }
   for (var i = 0; i < datos.length; i++) {
     var item = datos[i];
     var fila = [];

--- a/build.js
+++ b/build.js
@@ -75,9 +75,10 @@ function buildConsolidatedFile() {
     // Objeto para almacenar todas las constantes
     const allConstants = {};
 
+    // Header sin timestamp: el build debe ser determinista (CI hace git diff --exit-code)
     let consolidatedContent = '// Archivo consolidado generado automáticamente\n';
-    consolidatedContent += '// Fecha de generación: ' + new Date().toISOString() + '\n\n';
-    
+    consolidatedContent += '// No editar a mano: npm run build\n\n';
+
     // Agregar el namespace CONSTANTS al inicio
     consolidatedContent += '// Namespace para constantes compartidas\n';
     consolidatedContent += 'var CONSTANTS = {};\n';

--- a/doc/CEDEAR.md
+++ b/doc/CEDEAR.md
@@ -9,16 +9,19 @@ El proyecto incluye un archivo `data/cedears.json` que contiene información út
 Cada entrada del archivo contiene:
 - **Cedears**: Símbolo/ticker del CEDEAR
 - **Name**: Nombre completo de la empresa
-- **Ratio**: Ratio de conversión entre el CEDEAR y la acción subyacente
+- **Ratio**: Ratio de conversión entre el CEDEAR y la acción subyacente (string)
 
-Ejemplo de uso:
-```json
-{
-  "Cedears": "AAPL",
-  "Name": "Apple Inc",
-  "Ratio": "20"
-}
-```
+### Formatos de `ratio`
+
+La función `=cedear(symbol; "ratio")` devuelve el string del JSON **sin transformarlo**:
+
+| Formato | Ejemplo | Significado habitual |
+|--------|---------|----------------------|
+| Número como string | `"20"` | 20 CEDEARs = 1 acción subyacente (ej. AAPL) |
+| Razón `A:B` | `"1:3"` | Ratio 1 a 3 (presente en ~16 tickers del listado) |
+
+Si necesitás operar matemáticamente, parseá el string en la hoja (por ejemplo con `SPLIT` / `VALUE`) según el formato del ticker.
+
 
 ## Uso
 

--- a/doc/DOLAR.md
+++ b/doc/DOLAR.md
@@ -13,28 +13,34 @@ En cualquier celda de la hoja, escribe:
 ## Parámetros
 
 **tipo (string):**
-- Tipo de dólar a consultar (ej: "blue", "oficial", "mayorista")
-- Tipos disponibles: blue, oficial, mayorista, y otros disponibles en la API
+- Tipo de dólar a consultar
+- Tipos de la API: `oficial`, `blue`, `bolsa`, `contadoconliqui`, `mayorista`, `cripto`, `tarjeta`
+- **Aliases:**
+  - `mep` → `bolsa`
+  - `ccl`, `contado` → `contadoconliqui`
 
-**operación (string):**
-- Tipo de operación a consultar: "compra", "venta", "promedio"
-- Por defecto: "venta"
+**operación (string):** [Opcional]
+- Tipo de operación: `compra`, `venta`, `promedio`
+- Por defecto: `venta`
 
 ## Ejemplos
 
 | Fórmula | Descripción |
 |---------|-------------|
 | `=dolar("blue")` | Precio de venta del dólar blue |
-| `=dolar("oficial")` | Precio de venta del dólar oficial |
-| `=dolar("mayorista")` | Precio de venta del dólar mayorista |
-| `=dolar("blue"; "compra")` | Precio de compra del dólar blue |
-| `=dolar("oficial"; "venta")` | Precio de compra del dólar oficial |
+| `=dolar("oficial"; "compra")` | Precio de compra del dólar oficial |
+| `=dolar("mep"; "venta")` | MEP (alias de bolsa) |
+| `=dolar("ccl"; "promedio")` | CCL (alias de contadoconliqui) |
 | `=dolar("mayorista"; "promedio")` | Precio promedio del dólar mayorista |
+
+## Notas
+
+- Las cotizaciones se cachean ~60 segundos en Apps Script (`CacheService`) para reducir llamadas a la API cuando muchas celdas piden el mismo dato.
 
 ## Errores comunes
 
 **Tipo inválido**  
-"Tipo inválido: 'xyz'. Tipos disponibles: oficial, blue, bolsa, contadoconliqui, mayorista, cripto, tarjeta."
+"Tipo inválido: 'xyz'. Tipos disponibles: oficial, blue, bolsa, contadoconliqui, mayorista, cripto, tarjeta (aliases: mep→bolsa, ccl→contadoconliqui)."
 
 **Operación inválida**  
 "Operación inválida: 'xyz'. Usa 'compra', 'venta' o 'promedio'."

--- a/doc/DOLAR_HISTORICO.md
+++ b/doc/DOLAR_HISTORICO.md
@@ -8,31 +8,39 @@ En cualquier celda de la hoja, escribe:
 
 ```
 =dolar_historico("tipo"; "fecha"; "valor")
+=dolar_historico_todos("fecha")
 ```
 
 ## Parámetros
 
 **tipo (string):**
-- Tipo de dólar a consultar (ej: "blue", "oficial", "mayorista")
-- Tipos disponibles: blue, oficial, mayorista, y otros disponibles en la API
+- Tipo de dólar a consultar (ej: `blue`, `oficial`, `mayorista`)
+- Mismos aliases que `dolar()`: `mep` → `bolsa`, `ccl` → `contadoconliqui`
 
 **fecha (string):** [Opcional]
 - Fecha para la cual se quiere obtener la cotización
-- Formato aceptado: "YYYY-MM-DD"
-- Si se omite, usa la fecha actual
+- Formato aceptado: `YYYY-MM-DD` o `DD/MM/YYYY`
+- Si se omite, usa la fecha actual (Argentina, GMT-3)
 
 **valor (string):** [Opcional]
-- Valor a devolver: "compra" o "venta"
-- Por defecto: "venta"
+- Valor a devolver: `compra` o `venta`
+- Por defecto: `venta`
+
+## Cómo funciona
+
+- `dolar_historico` consulta el endpoint filtrado de ArgentinaDatos:
+  `GET /v1/cotizaciones/dolares/{casa}/{YYYY}/{MM}/{DD}`
+- `dolar_historico_todos` usa la serie completa (cacheada ~5 min) y filtra por fecha en cliente
 
 ## Ejemplos
 
 | Fórmula | Descripción |
 |---------|-------------|
-| `=dolar_historico("blue"; "2023-01-15")` | Valor de venta del dólar blue el 15 de enero de 2023 |
-| `=dolar_historico("oficial"; "2023-01-15"; "compra")` | Valor de compra del dólar oficial el 15 de enero de 2023 |
-| `=dolar_historico("mayorista")` | Valor de venta del dólar mayorista para la fecha actual |
-| `=dolar_historico_todos("2023-01-15")` | Tabla con todas las cotizaciones disponibles para el 15 de enero de 2023 |
+| `=dolar_historico("blue"; "2023-01-15")` | Venta del blue el 15 de enero de 2023 |
+| `=dolar_historico("oficial"; "15/01/2023"; "compra")` | Compra del oficial (formato AR) |
+| `=dolar_historico("mep"; "2023-01-15")` | MEP histórico |
+| `=dolar_historico("mayorista")` | Venta del mayorista para hoy |
+| `=dolar_historico_todos("2023-01-15")` | Tabla con todas las casas de esa fecha |
 
 ## Errores comunes
 

--- a/src/acciones.js
+++ b/src/acciones.js
@@ -9,60 +9,21 @@
  * @customfunction
  */
 function acciones(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de acciones disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_stocks',
+    symbol,
+    value,
+    'acciones',
+    'panel:arg_stocks'
+  );
 }
 
 /**
  * Obtiene la lista completa de acciones que cotizan en el mercado argentino desde la API.
- * 
+ *
  * @return Un arreglo bidimensional con todas las acciones y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function accionesLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada acción como una fila
-  datos.forEach(function(accion) {
-    var fila = columnas.map(function(columna) {
-      return accion[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_stocks', 'panel:arg_stocks');
 }

--- a/src/bcra.js
+++ b/src/bcra.js
@@ -7,20 +7,12 @@
  */
 function bcraVariables() {
   try {
-    // Fetch data from the BCRA API
-    const url = "https://api.bcra.gob.ar/estadisticas/v3.0/Monetarias";
-    const response = UrlFetchApp.fetch(url);
-    const data = JSON.parse(response.getContentText());
-    
-    // Check if the API response is valid
-    if (data.status !== 200 || !data.results || !Array.isArray(data.results)) {
-      throw new Error("Error en la respuesta de la API del BCRA.");
-    }
-    
-    // Return the array of results
-    return data.results.map(item => [item.categoria, item.idVariable, item.descripcion, item.valor, item.fecha]);
+    var data = fetchBcraMonetarias_();
+    return data.results.map(function(item) {
+      return [item.categoria, item.idVariable, item.descripcion, item.valor, item.fecha];
+    });
   } catch (error) {
-    throw new Error(`Error al consultar el BCRA: ${error.message}`);
+    throw new Error("Error al consultar el BCRA: " + error.message);
   }
 }
 
@@ -33,35 +25,41 @@ function bcraVariables() {
  * @customfunction
  */
 function bcra(id) {
-  // Validate input
-  if (!id || isNaN(parseInt(id))) {
+  if (id === undefined || id === null || id === '' || isNaN(parseInt(id, 10))) {
     throw new Error("ID inválido. Debe ser un número válido (1, 4, 5, 6, etc).");
   }
-  
-  // Convert to integer in case it's passed as a string
-  const variableId = parseInt(id);
-  
+
+  var variableId = parseInt(id, 10);
+
   try {
-    // Fetch data from the BCRA API
-    const url = "https://api.bcra.gob.ar/estadisticas/v3.0/Monetarias";
-    const response = UrlFetchApp.fetch(url);
-    const data = JSON.parse(response.getContentText());
-    
-    // Check if the API response is valid
-    if (data.status !== 200 || !data.results || !Array.isArray(data.results)) {
-      throw new Error("Error en la respuesta de la API del BCRA.");
-    }
-    
-    // Find the variable with the specified ID
-    const variable = data.results.find(item => Number(item.idVariable) === variableId);
-    
-    // Return the value if found, otherwise throw an error
+    var data = fetchBcraMonetarias_();
+    var variable = data.results.find(function(item) {
+      return Number(item.idVariable) === variableId;
+    });
+
     if (variable) {
       return variable.valor;
-    } else {
-      throw new Error(`Variable con ID ${variableId} no encontrada. IDs disponibles: ${data.results.map(item => item.idVariable).join(', ')}.`);
     }
+    throw new Error(
+      "Variable con ID " + variableId + " no encontrada. IDs disponibles: " +
+      data.results.map(function(item) { return item.idVariable; }).join(', ') + "."
+    );
   } catch (error) {
-    throw new Error(`Error al consultar el BCRA: ${error.message}`);
+    throw new Error("Error al consultar el BCRA: " + error.message);
   }
+}
+
+/**
+ * @return {{status: number, results: Array}}
+ */
+function fetchBcraMonetarias_() {
+  var data = fetchJson("https://api.bcra.gob.ar/estadisticas/v3.0/Monetarias", {
+    cacheKey: 'api:bcra:monetarias',
+    cacheTtlSeconds: 300
+  });
+
+  if (data.status !== 200 || !data.results || !Array.isArray(data.results)) {
+    throw new Error("Error en la respuesta de la API del BCRA.");
+  }
+  return data;
 }

--- a/src/bonos.js
+++ b/src/bonos.js
@@ -9,60 +9,21 @@
  * @customfunction
  */
 function bonos(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_bonds';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de bonos disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_bonds',
+    symbol,
+    value,
+    'bonos',
+    'panel:arg_bonds'
+  );
 }
 
 /**
  * Obtiene la lista completa de bonos que cotizan en el mercado argentino desde la API.
- * 
+ *
  * @return {Array} Un arreglo con todos los bonos y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function bonosLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_bonds';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada bono como una fila
-  datos.forEach(function(bono) {
-    var fila = columnas.map(function(columna) {
-      return bono[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_bonds', 'panel:arg_bonds');
 }

--- a/src/caucion.js
+++ b/src/caucion.js
@@ -236,6 +236,9 @@ function calcularCaucion(
   if (!Number.isInteger(dias)) {
     throw new Error("El parámetro 'dias' debe ser un número entero.");
   }
+  if (dias === 0) {
+    throw new Error("El parámetro 'dias' no puede ser 0. Usar un valor positivo (tomadora) o negativo (colocadora).");
+  }
   if (typeof tna !== "number" || tna < 0) {
     throw new Error("El parámetro 'tna' debe ser un número positivo.");
   }

--- a/src/cedear.js
+++ b/src/cedear.js
@@ -10,46 +10,34 @@
  * @customfunction
  */
 function cedear(symbol, value) {
-  // Normalizo entradas
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
+  }
+  if (value === undefined || value === null || value === '') {
+    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio.");
+  }
+
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos para API de cotizaciones
-  var atributosPermitidosApi = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Valores permitidos para JSON local
+
   var atributosPermitidosJson = ['name', 'ratio'];
-  
-  // Verificar si es un atributo que viene del archivo JSON local
+
   if (atributosPermitidosJson.includes(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
   }
-  
-  // Si no es del JSON local, verificar si es un atributo válido de la API
-  if (!atributosPermitidosApi.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio.");
-  }
-  
-  // Consulta al API para cotizaciones
-  var url = 'https://data912.com/live/arg_cedears';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de CEDEARs disponibles.");
+
+  return panelCotizacion(
+    'https://data912.com/live/arg_cedears',
+    simbolo,
+    atributo,
+    'CEDEARs',
+    'panel:arg_cedears'
+  );
 }
 
 /**
  * Obtiene datos de CEDEARs desde el archivo JSON local.
- * 
+ *
  * @param {string} symbol El símbolo del CEDEAR
  * @param {string} attribute El atributo que se quiere obtener ('name' o 'ratio')
  * @return El valor del atributo solicitado
@@ -60,6 +48,7 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
       if (attribute === 'name') {
         return cedears[i].Name;
       } else if (attribute === 'ratio') {
+        // Se devuelve el string original del JSON ("20" o "1:3"). Ver doc/CEDEAR.md.
         return cedears[i].Ratio;
       }
     }
@@ -77,9 +66,13 @@ function cargarCedearsDesdeDrive() {
 }
 
 function cargarCedearsDesdeGitHub() {
-  var url = 'https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/data/cedears.json';
-  var response = UrlFetchApp.fetch(url);
-  return JSON.parse(response.getContentText());
+  return fetchJson(
+    'https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/data/cedears.json',
+    {
+      cacheKey: 'cedears:json',
+      cacheTtlSeconds: 3600
+    }
+  );
 }
 
 function getCedearDataFromJson(symbol, attribute) {
@@ -104,29 +97,10 @@ function getCedearDataFromJson(symbol, attribute) {
 
 /**
  * Obtiene la lista completa de CEDEARs (Certificados de Depósito Argentinos) desde la API.
- * 
+ *
  * @return Un arreglo bidimensional con todos los CEDEARs y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function cedearLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_cedears';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada CEDEAR como una fila
-  datos.forEach(function(cedear) {
-    var fila = columnas.map(function(columna) {
-      return cedear[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_cedears', 'panel:arg_cedears');
 }

--- a/src/criptoya.js
+++ b/src/criptoya.js
@@ -10,122 +10,83 @@
  * @customfunction
  */
 function criptoya(coin, fiat, volumen, exchange, operacion) {
-  // Valores por defecto
+  if (coin === undefined || coin === null || coin === '') {
+    throw new Error("Criptomoneda no proporcionada (ej: 'BTC', 'USDT').");
+  }
+  if (fiat === undefined || fiat === null || fiat === '') {
+    throw new Error("Moneda fiat no proporcionada (ej: 'ARS', 'USD').");
+  }
+
   volumen = volumen || 1;
   operacion = operacion || 'totalCompra';
-  
-  // Normalizo entradas
+
   var cripto = coin.toString().toUpperCase().trim();
   var moneda = fiat.toString().toUpperCase().trim();
   var vol = parseFloat(volumen);
   var tipoOperacion = operacion.toString().toLowerCase().trim();
-  
-  // Mapeo de nombres de operación a los campos de la API
+
   var camposOperacion = {
     'compra': 'ask',
     'totalcompra': 'totalAsk',
     'venta': 'bid',
     'totalventa': 'totalBid'
   };
-  
-  // Verificar si la operación es válida
+
   if (!Object.keys(camposOperacion).includes(tipoOperacion)) {
     throw new Error("Operación inválida: '" + operacion + "'. Operaciones disponibles: compra, totalCompra, venta, totalVenta.");
   }
-  
-  // Campo a consultar en la respuesta
+
   var campo = camposOperacion[tipoOperacion];
-  
-  // URL de la API de CriptoYa
   var url = 'https://criptoya.com/api/' + encodeURIComponent(cripto) + '/' + encodeURIComponent(moneda) + '/' + vol;
-  
+
   try {
-    // Consulta al API
-    var respuesta = UrlFetchApp.fetch(url, {
-      muteHttpExceptions: true,
-      headers: {
-        'Accept': 'application/json'
-      }
+    var datos = fetchJson(url, {
+      headers: { 'Accept': 'application/json' },
+      cacheKey: 'criptoya:' + cripto + ':' + moneda + ':' + vol,
+      cacheTtlSeconds: 60
     });
-    
-    // Comprobar si la respuesta es válida
-    if (respuesta.getResponseCode() !== 200) {
-      var mensajeError = "Código de error: " + respuesta.getResponseCode();
-      try {
-        var error = JSON.parse(respuesta.getContentText());
-        if (error.message) {
-          mensajeError = error.message;
-        }
-      } catch (parseError) {
-        // Mantener mensaje por código HTTP si el cuerpo no es JSON
-      }
-      throw new Error(mensajeError);
-    }
-    
-    // Analizar la respuesta JSON
-    var datos = JSON.parse(respuesta.getContentText());
-    
-    // Si se solicita un exchange específico
+
     if (exchange) {
       var exchangeKey = exchange.toString().toLowerCase().trim();
-      
-      // Verificar si el exchange existe en la respuesta
+
       if (!datos[exchangeKey]) {
         var exchangesDisponibles = Object.keys(datos).join(', ');
         throw new Error("Exchange '" + exchange + "' no disponible. Exchanges disponibles: " + exchangesDisponibles);
       }
-      
-      // Verificar si el campo solicitado existe para ese exchange
+
       if (datos[exchangeKey][campo] === undefined) {
         throw new Error("El campo '" + operacion + "' no está disponible para el exchange '" + exchange + "'");
       }
-      
-      // Devolver el precio del exchange específico
+
       return datos[exchangeKey][campo];
     }
-    
-    // Si no se especifica exchange, buscar el mejor precio según la operación
+
     var mejorPrecio;
-    var mejorExchange;
-    
-    // Determinar el mejor precio según el tipo de operación
     if (tipoOperacion.includes('compra')) {
-      // Para compra, el mejor precio es el más bajo
       mejorPrecio = Infinity;
       for (var ex in datos) {
-        // Verificar que el exchange tenga el campo solicitado
         if (datos[ex][campo] !== undefined && datos[ex][campo] < mejorPrecio) {
           mejorPrecio = datos[ex][campo];
-          mejorExchange = ex;
         }
       }
     } else {
-      // Para venta, el mejor precio es el más alto
       mejorPrecio = -Infinity;
-      for (var ex in datos) {
-        // Verificar que el exchange tenga el campo solicitado
-        if (datos[ex][campo] !== undefined && datos[ex][campo] > mejorPrecio) {
-          mejorPrecio = datos[ex][campo];
-          mejorExchange = ex;
+      for (var ex2 in datos) {
+        if (datos[ex2][campo] !== undefined && datos[ex2][campo] > mejorPrecio) {
+          mejorPrecio = datos[ex2][campo];
         }
       }
     }
-    
-    // Verificar si se encontró algún precio
+
     if (mejorPrecio === Infinity || mejorPrecio === -Infinity) {
       throw new Error("No se encontraron precios disponibles para " + cripto + "/" + moneda + " con el tipo de operación '" + operacion + "'");
     }
-    
-    // Devolver el mejor precio
+
     return mejorPrecio;
-    
   } catch (e) {
-    // Si el error indica que la moneda o criptomoneda no es válida
     if (e.message.includes("Not Found") || e.message.includes("404")) {
       throw new Error("Par " + cripto + "/" + moneda + " no encontrado. Verifica que la cripto y la moneda sean correctas.");
     }
-    
-    // Para otros errores, mostrar el mensaje original
     throw new Error("Error al consultar precio de " + cripto + "/" + moneda + ": " + e.message);
   }
-} 
+}

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -7,60 +7,33 @@
  * @customfunction
  */
 function crypto(symbol, moneda) {
-  // Valor por defecto
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'BTC').");
+  }
+
   moneda = moneda || 'USD';
-  
-  // Normalizo entradas
+
   var cripto = symbol.toString().toUpperCase().trim();
   var divisa = moneda.toString().toUpperCase().trim();
-  
-  // Par de trading
   var par = cripto + '-' + divisa;
-  
-  // URL de la API de Coinbase (versión pública)
-  var url = 'https://api.coinbase.com/v2/prices/' + par + '/spot';
-  
+  var url = 'https://api.coinbase.com/v2/prices/' + encodeURIComponent(par) + '/spot';
+
   try {
-    // Consulta al API
-    var respuesta = UrlFetchApp.fetch(url, {
-      muteHttpExceptions: true,
-      headers: {
-        'Accept': 'application/json'
-      }
+    var datos = fetchJson(url, {
+      headers: { 'Accept': 'application/json' },
+      cacheKey: 'crypto:' + par,
+      cacheTtlSeconds: 60
     });
-    
-    // Comprobar si la respuesta es válida
-    if (respuesta.getResponseCode() !== 200) {
-      var mensajeError = "Código de error: " + respuesta.getResponseCode();
-      try {
-        var error = JSON.parse(respuesta.getContentText());
-        if (error.errors && error.errors[0] && error.errors[0].message) {
-          mensajeError = error.errors[0].message;
-        }
-      } catch (parseError) {
-        // Mantener mensaje por código HTTP si el cuerpo no es JSON
-      }
-      throw new Error(mensajeError);
-    }
-    
-    // Analizar la respuesta JSON
-    var datos = JSON.parse(respuesta.getContentText());
-    
-    // Verificar si se recibió correctamente la respuesta
+
     if (!datos || !datos.data || !datos.data.amount) {
       throw new Error("Respuesta inválida de Coinbase");
     }
-    
-    // Devolver el precio
+
     return parseFloat(datos.data.amount);
-    
   } catch (e) {
-    // Si el error indica que no se encontró el par de trading
     if (e.message.includes("Not Found") || e.message.includes("404")) {
       throw new Error("Par de trading no encontrado: '" + par + "'. Verifica que el símbolo y la moneda sean correctos.");
     }
-    
-    // Para otros errores, mostrar el mensaje original
     throw new Error("Error al consultar el precio de " + cripto + ": " + e.message);
   }
-} 
+}

--- a/src/dolar.js
+++ b/src/dolar.js
@@ -1,41 +1,64 @@
 /**
  * Obtiene la cotización de los distintos tipos de dólar en Argentina.
  *
- * @param {string} tipo La “casa” del dólar: oficial, blue, bolsa, contadoconliqui, mayorista, cripto o tarjeta.
- * @param {string} operacion 'compra', 'venta' o 'promedio'.
+ * @param {string} tipo La “casa” del dólar: oficial, blue, bolsa/mep, contadoconliqui/ccl, mayorista, cripto o tarjeta.
+ * @param {string} operacion 'compra', 'venta' o 'promedio'. Por defecto: 'venta'.
  * @return El valor numérico de la operación solicitada.
  * @customfunction
  */
 function dolar(tipo, operacion) {
-  // Consulta al API
-  var url = 'https://dolarapi.com/v1/dolares';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var casa = tipo.toString().toLowerCase().trim();
+  if (tipo === undefined || tipo === null || tipo === '') {
+    throw new Error("Tipo no proporcionado. Usa 'blue', 'oficial', 'mep', 'ccl', etc.");
+  }
+
+  operacion = (operacion === undefined || operacion === null || operacion === '')
+    ? 'venta'
+    : operacion;
+
+  var casa = normalizarCasaDolar_(tipo);
   var op = operacion.toString().toLowerCase().trim();
-  
-  // Busco la casa solicitada
+
+  var datos = fetchJson('https://dolarapi.com/v1/dolares', {
+    cacheKey: 'api:dolarapi:dolares',
+    cacheTtlSeconds: 60
+  });
+
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].casa.toLowerCase() === casa) {
       var compra = datos[i].compra;
-      var venta  = datos[i].venta;
-      
-      if (op === 'compra')     return compra;
-      if (op === 'venta')      return venta;
+      var venta = datos[i].venta;
+
+      if (op === 'compra') return compra;
+      if (op === 'venta') return venta;
       if (op === 'promedio') {
         if (compra != null && venta != null) return (compra + venta) / 2;
         if (compra != null) return compra;
         if (venta != null) return venta;
         throw new Error("No hay cotización disponible para calcular el promedio de '" + tipo + "'.");
       }
-      
+
       throw new Error("Operación inválida: '" + operacion + "'. Usa 'compra', 'venta' o 'promedio'.");
     }
   }
-  
-  // Si no encontró la casa
-  var disponibles = datos.map(function(o){ return o.casa; }).join(', ');
-  throw new Error("Tipo inválido: '" + tipo + "'. Tipos disponibles: " + disponibles + ".");
+
+  var disponibles = datos.map(function(o) { return o.casa; }).join(', ');
+  throw new Error("Tipo inválido: '" + tipo + "'. Tipos disponibles: " + disponibles + " (aliases: mep→bolsa, ccl→contadoconliqui).");
+}
+
+/**
+ * Normaliza aliases comunes de casas de dólar.
+ *
+ * @param {*} tipo
+ * @return {string}
+ */
+function normalizarCasaDolar_(tipo) {
+  var casa = tipo.toString().toLowerCase().trim().replace(/\s+/g, '');
+
+  if (casa === 'mep' || casa === 'bolsa') {
+    return 'bolsa';
+  }
+  if (casa === 'ccl' || casa === 'contado' || casa === 'contadoconliqui' || casa === 'contadoconliquidacion') {
+    return 'contadoconliqui';
+  }
+  return casa;
 }

--- a/src/dolar_historico.js
+++ b/src/dolar_historico.js
@@ -1,7 +1,7 @@
 /**
  * Obtiene la cotización histórica del dólar según el tipo y fecha especificados
- * 
- * @param {string} tipo - Tipo de dólar (blue, oficial, mayorista, etc.)
+ *
+ * @param {string} tipo - Tipo de dólar (blue, oficial, mayorista, mep, ccl, etc.)
  * @param {string} fecha - Fecha en formato YYYY-MM-DD o DD/MM/YYYY
  * @param {string} valor - Opcional: "compra" o "venta" (por defecto es "venta")
  * @return {number} Valor de la cotización para el tipo y fecha solicitados
@@ -10,77 +10,86 @@
 function dolar_historico(tipo, fecha, valor) {
   valor = valor || "venta";
 
-  // URL de la API de ArgentinaDatos para cotizaciones de dólares
-  const url = 'https://api.argentinadatos.com/v1/cotizaciones/dolares';
-
   if (!tipo) {
     throw new Error("Debe especificar un tipo de dólar");
   }
 
+  var casa = normalizarCasaDolar_(tipo);
+
   // Si no se proporciona fecha, usar la fecha actual en Argentina
+  var fechaISO;
   if (!fecha) {
-    const hoy = new Date();
-    fecha = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
+    var hoy = new Date();
+    fechaISO = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
   } else {
     try {
-      fecha = formatearFechaISO(fecha);
+      fechaISO = formatearFechaISO(fecha);
     } catch (e) {
       throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
     }
   }
 
-  if (valor.toLowerCase() !== "compra" && valor.toLowerCase() !== "venta") {
+  var campo = valor.toString().toLowerCase().trim();
+  if (campo !== "compra" && campo !== "venta") {
     throw new Error("El valor debe ser 'compra' o 'venta'");
   }
 
-  const response = UrlFetchApp.fetch(url);
-  const data = JSON.parse(response.getContentText());
+  var componentes = obtenerComponentesFecha(fechaISO);
+  var url = 'https://api.argentinadatos.com/v1/cotizaciones/dolares/' +
+    encodeURIComponent(casa) + '/' +
+    componentes.year + '/' + componentes.month + '/' + componentes.day;
 
-  const cotizacion = data.filter(item =>
-    item.casa.toLowerCase() === tipo.toLowerCase() &&
-    item.fecha === fecha
-  );
-
-  if (cotizacion.length > 0) {
-    return cotizacion[0][valor.toLowerCase()];
+  try {
+    var cotizacion = fetchJson(url, { skipCache: true });
+    if (cotizacion && cotizacion[campo] != null) {
+      return cotizacion[campo];
+    }
+    throw new Error("No se encontró cotización para la fecha y tipo especificados");
+  } catch (e) {
+    if (e.message && e.message.indexOf('Error HTTP') === 0) {
+      throw new Error("No se encontró cotización para la fecha y tipo especificados");
+    }
+    throw e;
   }
-
-  throw new Error("No se encontró cotización para la fecha y tipo especificados");
 }
 
 /**
  * Obtiene todas las cotizaciones de dólar para una fecha específica
- * 
+ *
  * @param {string} fecha - Fecha en formato YYYY-MM-DD o DD/MM/YYYY
  * @return {Array} Matriz con las cotizaciones de cada tipo de dólar para la fecha
  * @customfunction
  */
 function dolar_historico_todos(fecha) {
-  const url = 'https://api.argentinadatos.com/v1/cotizaciones/dolares';
-
+  var fechaISO;
   if (!fecha) {
-    const hoy = new Date();
-    fecha = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
+    var hoy = new Date();
+    fechaISO = Utilities.formatDate(hoy, "GMT-3", "yyyy-MM-dd");
   } else {
     try {
-      fecha = formatearFechaISO(fecha);
+      fechaISO = formatearFechaISO(fecha);
     } catch (e) {
       throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
     }
   }
 
-  const response = UrlFetchApp.fetch(url);
-  const data = JSON.parse(response.getContentText());
+  // Serie completa cacheada (payload grande: solo cachear si entra en el límite de CacheService)
+  var data = fetchJson('https://api.argentinadatos.com/v1/cotizaciones/dolares', {
+    cacheKey: 'api:ad:dolares:all',
+    cacheTtlSeconds: 300
+  });
 
-  const cotizaciones = data.filter(item => item.fecha === fecha);
+  var cotizaciones = data.filter(function(item) {
+    return item.fecha === fechaISO;
+  });
 
   if (cotizaciones.length === 0) {
     throw new Error("No se encontraron cotizaciones para la fecha especificada");
   }
 
-  const resultado = [["Tipo", "Compra", "Venta", "Fecha"]];
+  var resultado = [["Tipo", "Compra", "Venta", "Fecha"]];
 
-  cotizaciones.forEach(cotizacion => {
+  cotizaciones.forEach(function(cotizacion) {
     resultado.push([
       cotizacion.casa,
       cotizacion.compra,

--- a/src/dolar_historico.js
+++ b/src/dolar_historico.js
@@ -39,11 +39,18 @@ function dolar_historico(tipo, fecha, valor) {
     encodeURIComponent(casa) + '/' +
     componentes.year + '/' + componentes.month + '/' + componentes.day;
 
-  var cotizacion = fetchJson(url, { skipCache: true });
-  if (cotizacion && cotizacion[campo] != null) {
-    return cotizacion[campo];
+  try {
+    var cotizacion = fetchJson(url, { skipCache: true });
+    if (cotizacion && cotizacion[campo] != null) {
+      return cotizacion[campo];
+    }
+    throw new Error("No se encontró cotización para la fecha y tipo especificados");
+  } catch (e) {
+    if (e.message && e.message.indexOf('Error HTTP') === 0) {
+      throw new Error("No se encontró cotización para la fecha y tipo especificados");
+    }
+    throw e;
   }
-  throw new Error("No se encontró cotización para la fecha y tipo especificados");
 }
 
 /**

--- a/src/dolar_historico.js
+++ b/src/dolar_historico.js
@@ -39,18 +39,11 @@ function dolar_historico(tipo, fecha, valor) {
     encodeURIComponent(casa) + '/' +
     componentes.year + '/' + componentes.month + '/' + componentes.day;
 
-  try {
-    var cotizacion = fetchJson(url, { skipCache: true });
-    if (cotizacion && cotizacion[campo] != null) {
-      return cotizacion[campo];
-    }
-    throw new Error("No se encontró cotización para la fecha y tipo especificados");
-  } catch (e) {
-    if (e.message && e.message.indexOf('Error HTTP') === 0) {
-      throw new Error("No se encontró cotización para la fecha y tipo especificados");
-    }
-    throw e;
+  var cotizacion = fetchJson(url, { skipCache: true });
+  if (cotizacion && cotizacion[campo] != null) {
+    return cotizacion[campo];
   }
+  throw new Error("No se encontró cotización para la fecha y tipo especificados");
 }
 
 /**

--- a/src/fci.js
+++ b/src/fci.js
@@ -9,19 +9,16 @@
  * @customfunction
  */
 function fci(tipoFondo, nombreFondo, fecha, campo) {
-  // Normalizo entradas
   var tipo = tipoFondo ? tipoFondo.toString().toLowerCase().trim() : '';
   var nombre = nombreFondo ? nombreFondo.toString().trim() : '';
   var campoDatos = campo ? campo.toString().toLowerCase().trim() : 'vcp';
 
-  // Validar tipo de fondo (normalización con replace global)
   var tipoNormalizado = tipo.replace(/\s+/g, '').replace(/[óo]/g, 'o');
   var tiposPermitidos = ['mercadodinero', 'rentavariable', 'rentafija', 'rentamixta', 'retornototal'];
   if (!tiposPermitidos.includes(tipoNormalizado)) {
     throw new Error("Tipo de fondo inválido. Tipos permitidos: mercadoDinero, rentaVariable, rentaFija, rentaMixta, retornoTotal.");
   }
 
-  // Convertir tipo a formato de API
   var tipoAPI = tipoNormalizado;
   switch (tipoAPI) {
     case 'mercadodinero': tipoAPI = 'mercadoDinero'; break;
@@ -31,19 +28,17 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     case 'retornototal': tipoAPI = 'retornoTotal'; break;
   }
 
-  // Validar el campo a consultar
   var camposPermitidos = ['vcp', 'ccp', 'patrimonio'];
   if (!camposPermitidos.includes(campoDatos)) {
     throw new Error("Campo inválido. Campos permitidos: vcp (valor cuotaparte), ccp (cantidad cuotapartes), patrimonio.");
   }
 
-  // Validar que se haya proporcionado un nombre de fondo
   if (!nombre) {
     throw new Error("Debe especificar un nombre de fondo.");
   }
 
-  // Construir URL según si se proporciona fecha o no
   var url;
+  var cacheKey = null;
   if (fecha) {
     try {
       var componentesFecha = obtenerComponentesFecha(fecha);
@@ -53,20 +48,14 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
     }
   } else {
     url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipoAPI + '/ultimo';
+    cacheKey = 'api:ad:fci:' + tipoAPI + ':ultimo';
   }
 
   try {
-    // Consulta al API
-    var respuesta = UrlFetchApp.fetch(url, {
-      muteHttpExceptions: true
-    });
-
-    // Verificar si la respuesta es válida
-    if (respuesta.getResponseCode() !== 200) {
-      throw new Error("Error al consultar la API: Código " + respuesta.getResponseCode() + ". Verifique los parámetros.");
-    }
-
-    var datos = JSON.parse(respuesta.getContentText());
+    var datos = fetchJson(url, cacheKey ? {
+      cacheKey: cacheKey,
+      cacheTtlSeconds: 120
+    } : { skipCache: true });
 
     function esFondoValido(item) {
       return item.fondo && !item.fondo.startsWith("Region:") &&
@@ -83,45 +72,54 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
       return valor;
     }
 
-    // Buscar el fondo por nombre (exacto primero, luego parcial sin ambigüedad)
+    var nombreLower = nombre.toLowerCase();
     var coincidenciasExactas = [];
+    var coincidenciasExactasCI = [];
     var coincidenciasParciales = [];
+    var coincidenciasParcialesCI = [];
+
     for (var i = 0; i < datos.length; i++) {
       if (!esFondoValido(datos[i])) continue;
-      if (datos[i].fondo === nombre) {
+      var fondoNombre = datos[i].fondo;
+      var fondoLower = fondoNombre.toLowerCase();
+
+      if (fondoNombre === nombre) {
         coincidenciasExactas.push(datos[i]);
-      } else if (datos[i].fondo.includes(nombre)) {
+      } else if (fondoLower === nombreLower) {
+        coincidenciasExactasCI.push(datos[i]);
+      } else if (fondoNombre.includes(nombre)) {
         coincidenciasParciales.push(datos[i]);
+      } else if (fondoLower.includes(nombreLower)) {
+        coincidenciasParcialesCI.push(datos[i]);
       }
     }
 
-    if (coincidenciasExactas.length === 1) {
-      return valorCampoFondo(coincidenciasExactas[0]);
-    }
-    if (coincidenciasExactas.length > 1) {
-      throw new Error("Varios fondos coinciden con '" + nombre + "': " + coincidenciasExactas.map(function(f) { return f.fondo; }).join(', ') + ".");
-    }
-    if (coincidenciasParciales.length === 1) {
-      return valorCampoFondo(coincidenciasParciales[0]);
-    }
-    if (coincidenciasParciales.length > 1) {
-      throw new Error("Varios fondos coinciden con '" + nombre + "': " + coincidenciasParciales.slice(0, 10).map(function(f) { return f.fondo; }).join(', ') + "...");
+    function resolverCoincidencias(lista) {
+      if (lista.length === 1) return valorCampoFondo(lista[0]);
+      if (lista.length > 1) {
+        throw new Error("Varios fondos coinciden con '" + nombre + "': " + lista.slice(0, 10).map(function(f) { return f.fondo; }).join(', ') + (lista.length > 10 ? "..." : "."));
+      }
+      return null;
     }
 
-    // Si no se encontró el fondo, mostrar algunos disponibles
+    var r = resolverCoincidencias(coincidenciasExactas);
+    if (r !== null) return r;
+    r = resolverCoincidencias(coincidenciasExactasCI);
+    if (r !== null) return r;
+    r = resolverCoincidencias(coincidenciasParciales);
+    if (r !== null) return r;
+    r = resolverCoincidencias(coincidenciasParcialesCI);
+    if (r !== null) return r;
+
     var fondosDisponibles = datos
-      .filter(function(d) {
-        return esFondoValido(d);
-      })
-      .map(function(d) {
-        return d.fondo;
-      })
+      .filter(esFondoValido)
+      .map(function(d) { return d.fondo; })
       .slice(0, 10)
       .join(", ") + "...";
 
     throw new Error("Fondo '" + nombre + "' no encontrado para el tipo '" + tipoFondo + "'. Algunos fondos disponibles: " + fondosDisponibles);
   } catch (e) {
-    if (e.message.includes("Error al consultar la API")) {
+    if (e.message.includes("Error HTTP") || e.message.includes("Error al consultar")) {
       throw e;
     }
     throw new Error("Error al consultar información de '" + tipoFondo + "': " + e.message);
@@ -135,56 +133,42 @@ function fci(tipoFondo, nombreFondo, fecha, campo) {
  * @customfunction
  */
 function fciLista() {
-  // Tipos de fondos a consultar
   var tipos = ['mercadoDinero', 'rentaVariable', 'rentaFija', 'rentaMixta', 'retornoTotal'];
-
-  // Matriz para almacenar todos los fondos
   var todosLosFondos = [['Nombre del Fondo', 'Tipo de Fondo', 'Valor Cuotaparte']];
 
-  // Recorrer cada tipo de fondo
   tipos.forEach(function(tipo) {
     try {
-      // Construir URL para obtener la lista de fondos
       var url = 'https://api.argentinadatos.com/v1/finanzas/fci/' + tipo + '/ultimo';
-
-      // Consultar la API
-      var respuesta = UrlFetchApp.fetch(url, {
-        muteHttpExceptions: true
+      var datos = fetchJson(url, {
+        cacheKey: 'api:ad:fci:' + tipo + ':ultimo',
+        cacheTtlSeconds: 120
       });
 
-      // Verificar si la respuesta es válida
-      if (respuesta.getResponseCode() === 200) {
-        var datos = JSON.parse(respuesta.getContentText());
+      var fondosValidos = datos.filter(function(d) {
+        return d.fondo &&
+               !d.fondo.startsWith("Region:") &&
+               !d.fondo.startsWith("Duration:") &&
+               !d.fondo.startsWith("Benchmark:") &&
+               !d.fondo.startsWith("Moneda:");
+      });
 
-        // Filtrar solo los fondos válidos (no categorías)
-        var fondosValidos = datos.filter(function(d) {
-          return d.fondo &&
-                 !d.fondo.startsWith("Region:") &&
-                 !d.fondo.startsWith("Duration:") &&
-                 !d.fondo.startsWith("Benchmark:") &&
-                 !d.fondo.startsWith("Moneda:");
-        });
+      fondosValidos.forEach(function(fondo) {
+        var nombreFormateado = tipo;
+        switch (tipo) {
+          case 'mercadoDinero': nombreFormateado = 'Mercado de Dinero'; break;
+          case 'rentaVariable': nombreFormateado = 'Renta Variable'; break;
+          case 'rentaFija': nombreFormateado = 'Renta Fija'; break;
+          case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
+          case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
+        }
 
-        // Agregar cada fondo a la matriz de resultados
-        fondosValidos.forEach(function(fondo) {
-          var nombreFormateado = tipo;
-          switch (tipo) {
-            case 'mercadoDinero': nombreFormateado = 'Mercado de Dinero'; break;
-            case 'rentaVariable': nombreFormateado = 'Renta Variable'; break;
-            case 'rentaFija': nombreFormateado = 'Renta Fija'; break;
-            case 'rentaMixta': nombreFormateado = 'Renta Mixta'; break;
-            case 'retornoTotal': nombreFormateado = 'Retorno Total'; break;
-          }
-
-          todosLosFondos.push([
-            fondo.fondo,
-            nombreFormateado,
-            fondo.vcp
-          ]);
-        });
-      }
+        todosLosFondos.push([
+          fondo.fondo,
+          nombreFormateado,
+          fondo.vcp
+        ]);
+      });
     } catch (e) {
-      // Si hay un error con un tipo de fondo, continuar con los demás
       Logger.log("Error al consultar fondos de tipo '" + tipo + "': " + e.message);
     }
   });

--- a/src/http.js
+++ b/src/http.js
@@ -1,0 +1,133 @@
+/**
+ * Helpers HTTP + cache para Google Apps Script.
+ * Usa CacheService.getScriptCache() cuando está disponible.
+ * Los valores de cache no están garantizados; siempre se puede re-fetchear.
+ */
+
+var HTTP_CACHE_MAX_CHARS = 90000; // margen bajo el límite ~100KB de CacheService
+var HTTP_DEFAULT_TTL = 120;
+
+/**
+ * Lee un valor del script cache. Devuelve null si no hay cache, falla o no hay key.
+ *
+ * @param {string} key
+ * @return {string|null}
+ */
+function cacheGet_(key) {
+  if (!key) return null;
+  try {
+    if (typeof CacheService === 'undefined' || !CacheService.getScriptCache) {
+      return null;
+    }
+    var cache = CacheService.getScriptCache();
+    if (!cache) return null;
+    return cache.get(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Guarda un valor en el script cache. Ignora fallos y payloads grandes.
+ *
+ * @param {string} key
+ * @param {string} value
+ * @param {number} ttlSeconds
+ */
+function cachePut_(key, value, ttlSeconds) {
+  if (!key || value == null) return;
+  if (value.length > HTTP_CACHE_MAX_CHARS) return;
+  try {
+    if (typeof CacheService === 'undefined' || !CacheService.getScriptCache) {
+      return;
+    }
+    var cache = CacheService.getScriptCache();
+    if (!cache) return;
+    var ttl = ttlSeconds || HTTP_DEFAULT_TTL;
+    if (ttl < 1) ttl = 1;
+    if (ttl > 21600) ttl = 21600;
+    cache.put(key, value, ttl);
+  } catch (e) {
+    // Cache es best-effort
+  }
+}
+
+/**
+ * Fetch JSON con muteHttpExceptions, validación de status y cache opcional.
+ *
+ * @param {string} url
+ * @param {Object} [options]
+ * @param {Object} [options.headers] Headers HTTP adicionales
+ * @param {string} [options.cacheKey] Clave de CacheService
+ * @param {number} [options.cacheTtlSeconds] TTL en segundos (default 120)
+ * @param {boolean} [options.skipCache] Si true, no lee ni escribe cache
+ * @return {*} JSON parseado
+ */
+function fetchJson(url, options) {
+  options = options || {};
+  var cacheKey = options.cacheKey;
+  var skipCache = options.skipCache === true;
+  var ttl = options.cacheTtlSeconds != null ? options.cacheTtlSeconds : HTTP_DEFAULT_TTL;
+
+  if (!skipCache && cacheKey) {
+    var cached = cacheGet_(cacheKey);
+    if (cached != null) {
+      try {
+        return JSON.parse(cached);
+      } catch (parseCacheError) {
+        // Cache corrupto: seguir con fetch
+      }
+    }
+  }
+
+  var fetchOptions = {
+    muteHttpExceptions: true,
+    headers: options.headers || {}
+  };
+
+  var respuesta;
+  try {
+    respuesta = UrlFetchApp.fetch(url, fetchOptions);
+  } catch (fetchError) {
+    throw new Error("Error de red al consultar la API: " + fetchError.message);
+  }
+
+  var code = respuesta.getResponseCode();
+  var text = respuesta.getContentText();
+
+  if (code < 200 || code >= 300) {
+    var detalle = text;
+    try {
+      var errBody = JSON.parse(text);
+      if (errBody && errBody.message) {
+        detalle = errBody.message;
+      } else if (errBody && errBody.error) {
+        detalle = errBody.error;
+      } else if (errBody && errBody.errors && errBody.errors[0] && errBody.errors[0].message) {
+        detalle = errBody.errors[0].message;
+      }
+    } catch (e) {
+      if (detalle && detalle.length > 200) {
+        detalle = detalle.substring(0, 200) + "...";
+      }
+    }
+    throw new Error("Error HTTP " + code + " al consultar la API: " + detalle);
+  }
+
+  var datos;
+  try {
+    datos = JSON.parse(text);
+  } catch (parseError) {
+    throw new Error("Respuesta inválida (no JSON) de la API.");
+  }
+
+  if (!skipCache && cacheKey) {
+    try {
+      cachePut_(cacheKey, text, ttl);
+    } catch (e) {
+      // ignore
+    }
+  }
+
+  return datos;
+}

--- a/src/inflacion.js
+++ b/src/inflacion.js
@@ -6,22 +6,19 @@
  * @customfunction
  */
 function inflacion(fecha) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/indices/inflacion';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/indices/inflacion', {
+    cacheKey: 'api:ad:inflacion',
+    cacheTtlSeconds: 300
+  });
 
   if (!datos || !datos.length) {
     throw new Error("No se recibieron datos de inflación desde la API.");
   }
 
-  // Si no se proporciona fecha, devolver el valor más reciente
-  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return datos[0].valor;
   }
 
@@ -32,14 +29,12 @@ function inflacion(fecha) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
 
-  // Buscar la fecha exacta
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].fecha === fechaFormateada) {
       return datos[i].valor;
     }
   }
 
-  // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
     return d.fecha <= fechaFormateada;
   });
@@ -48,11 +43,9 @@ function inflacion(fecha) {
     fechasMenores.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return fechasMenores[0].valor;
   }
 
-  // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
     return a.fecha.localeCompare(b.fecha);
   });

--- a/src/letras.js
+++ b/src/letras.js
@@ -7,74 +7,21 @@
  * @customfunction
  */
 function letras(symbol, valor) {
-  // Validate inputs
-  if (!symbol) {
-    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: BB2Y5, BNA6D, etc).");
-  }
-  
-  if (!valor) {
-    throw new Error("Valor no proporcionado. Valores disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Standardize symbol and value
-  symbol = symbol.toUpperCase().trim();
-  valor = valor.toLowerCase().trim();
-  
-  // Validate valor parameter
-  const validValues = ["c", "v", "q_bid", "px_bid", "px_ask", "q_ask", "q_op", "pct_change"];
-  if (!validValues.includes(valor)) {
-    throw new Error(`Atributo inválido: '${valor}'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.`);
-  }
-  
-  try {
-    // Fetch data from the API
-    const url = "https://data912.com/live/arg_notes";
-    const response = UrlFetchApp.fetch(url);
-    const letrasList = JSON.parse(response.getContentText());
-    
-    // Find the requested treasury bill
-    const letra = letrasList.find(letra => letra.symbol === symbol);
-    
-    // Return the value if found, otherwise throw an error
-    if (letra) {
-      return letra[valor];
-    } else {
-      throw new Error(`Símbolo inválido: '${symbol}'. No se encontró en la lista de letras disponibles.`);
-    }
-  } catch (error) {
-    throw new Error(`Error al consultar datos de letras: ${error.message}`);
-  }
+  return panelCotizacion(
+    'https://data912.com/live/arg_notes',
+    symbol,
+    valor,
+    'letras',
+    'panel:arg_notes'
+  );
 }
 
 /**
  * Obtiene la lista completa de letras del tesoro desde la API.
- * 
+ *
  * @return Un arreglo bidimensional con todas las letras y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function letrasLista() {
-  try {
-    // Fetch data from the API
-    const url = "https://data912.com/live/arg_notes";
-    const response = UrlFetchApp.fetch(url);
-    const datos = JSON.parse(response.getContentText());
-    
-    // Definir las columnas que queremos mostrar
-    const columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-    
-    // Crear el arreglo bidimensional comenzando con los encabezados
-    const resultado = [columnas];
-    
-    // Agregar cada letra como una fila
-    datos.forEach(function(letra) {
-      const fila = columnas.map(function(columna) {
-        return letra[columna];
-      });
-      resultado.push(fila);
-    });
-    
-    return resultado;
-  } catch (error) {
-    throw new Error(`Error al consultar datos de letras: ${error.message}`);
-  }
+  return panelLista('https://data912.com/live/arg_notes', 'panel:arg_notes');
 }

--- a/src/market_panel.js
+++ b/src/market_panel.js
@@ -1,0 +1,80 @@
+/**
+ * Helpers compartidos para paneles live de data912 (acciones, bonos, etc.).
+ */
+
+var ATRIBUTOS_PANEL = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
+
+/**
+ * Cotización de un símbolo en un panel live.
+ *
+ * @param {string} url URL del panel
+ * @param {*} symbol Símbolo del instrumento
+ * @param {*} value Atributo a devolver
+ * @param {string} nombreMercado Nombre para mensajes de error (ej: 'acciones')
+ * @param {string} cacheKey Clave de cache del panel
+ * @return {*} Valor del atributo
+ */
+function panelCotizacion(url, symbol, value, nombreMercado, cacheKey) {
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido.");
+  }
+  if (value === undefined || value === null || value === '') {
+    throw new Error("Atributo no proporcionado. Atributos disponibles: " + ATRIBUTOS_PANEL.join(', ') + ".");
+  }
+
+  var simbolo = symbol.toString().toUpperCase().trim();
+  var atributo = value.toString().toLowerCase().trim();
+
+  if (!ATRIBUTOS_PANEL.includes(atributo)) {
+    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: " + ATRIBUTOS_PANEL.join(', ') + ".");
+  }
+
+  var datos = fetchJson(url, {
+    cacheKey: cacheKey,
+    cacheTtlSeconds: 60
+  });
+
+  if (!datos || !datos.length) {
+    throw new Error("No se recibieron datos del panel de " + nombreMercado + ".");
+  }
+
+  for (var i = 0; i < datos.length; i++) {
+    if (datos[i].symbol === simbolo) {
+      return datos[i][atributo];
+    }
+  }
+
+  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de " + nombreMercado + " disponibles.");
+}
+
+/**
+ * Lista completa de un panel live como matriz (headers + filas).
+ *
+ * @param {string} url URL del panel
+ * @param {string} cacheKey Clave de cache del panel
+ * @return {Array}
+ */
+function panelLista(url, cacheKey) {
+  var datos = fetchJson(url, {
+    cacheKey: cacheKey,
+    cacheTtlSeconds: 60
+  });
+
+  if (!datos || !datos.length) {
+    throw new Error("No se recibieron datos del panel.");
+  }
+
+  var columnas = ATRIBUTOS_PANEL.slice();
+  columnas.unshift('symbol');
+
+  var resultado = [columnas];
+  for (var i = 0; i < datos.length; i++) {
+    var item = datos[i];
+    var fila = [];
+    for (var j = 0; j < columnas.length; j++) {
+      fila.push(item[columnas[j]]);
+    }
+    resultado.push(fila);
+  }
+  return resultado;
+}

--- a/src/market_panel.js
+++ b/src/market_panel.js
@@ -60,14 +60,13 @@ function panelLista(url, cacheKey) {
     cacheTtlSeconds: 60
   });
 
-  if (!datos || !datos.length) {
-    throw new Error("No se recibieron datos del panel.");
-  }
-
   var columnas = ATRIBUTOS_PANEL.slice();
   columnas.unshift('symbol');
 
   var resultado = [columnas];
+  if (!datos || !datos.length) {
+    return resultado;
+  }
   for (var i = 0; i < datos.length; i++) {
     var item = datos[i];
     var fila = [];

--- a/src/obligaciones.js
+++ b/src/obligaciones.js
@@ -9,60 +9,21 @@
  * @customfunction
  */
 function obligaciones(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_corp';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  var disponibles = datos.map(function(o){ return o.symbol; }).join(', ');
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de obligaciones negociables disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_corp',
+    symbol,
+    value,
+    'obligaciones negociables',
+    'panel:arg_corp'
+  );
 }
 
 /**
  * Obtiene la lista completa de obligaciones negociables que cotizan en el mercado argentino desde la API.
- * 
+ *
  * @return {Array} Un arreglo con todas las obligaciones negociables y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function obligacionesLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_corp';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada obligación negociable como una fila
-  datos.forEach(function(obligacion) {
-    var fila = columnas.map(function(columna) {
-      return obligacion[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
-} 
+  return panelLista('https://data912.com/live/arg_corp', 'panel:arg_corp');
+}

--- a/src/opciones.js
+++ b/src/opciones.js
@@ -9,59 +9,21 @@
  * @customfunction
  */
 function opciones(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_options';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  throw new Error("Símbolo de opción inválido: '" + symbol + "'. No se encontró en la lista de opciones disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/arg_options',
+    symbol,
+    value,
+    'opciones',
+    'panel:arg_options'
+  );
 }
 
 /**
  * Obtiene la lista completa de opciones (calls y puts) que cotizan en el mercado argentino.
- * 
+ *
  * @return Un arreglo bidimensional con todas las opciones y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function opcionesLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/arg_options';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada opción como una fila
-  datos.forEach(function(opcion) {
-    var fila = columnas.map(function(columna) {
-      return opcion[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/arg_options', 'panel:arg_options');
 }

--- a/src/plazofijo.js
+++ b/src/plazofijo.js
@@ -7,11 +7,11 @@
  * @customfunction
  */
 function plazofijo(banco, tipoCliente) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/tasas/plazoFijo';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/tasas/plazoFijo', {
+    cacheKey: 'api:ad:plazofijo',
+    cacheTtlSeconds: 120
+  });
+
   // Normalizo entradas
   var nombreBanco = banco ? banco.toString().toUpperCase().trim() : '';
   var tipo = tipoCliente ? tipoCliente.toString().toLowerCase().trim() : 'cliente';

--- a/src/rendimientos.js
+++ b/src/rendimientos.js
@@ -7,10 +7,10 @@
  * @customfunction
  */
 function rendimientos(moneda, proveedor) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/rendimientos';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/rendimientos', {
+    cacheKey: 'api:ad:rendimientos',
+    cacheTtlSeconds: 120
+  });
 
   // Normalizo entradas
   var crypto = moneda ? moneda.toString().toUpperCase().trim() : '';

--- a/src/riesgopais.js
+++ b/src/riesgopais.js
@@ -6,22 +6,19 @@
  * @customfunction
  */
 function riesgopais(fecha) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/indices/riesgo-pais';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/indices/riesgo-pais', {
+    cacheKey: 'api:ad:riesgo-pais',
+    cacheTtlSeconds: 300
+  });
 
   if (!datos || !datos.length) {
     throw new Error("No se recibieron datos de riesgo país desde la API.");
   }
 
-  // Si no se proporciona fecha, devolver el valor más reciente
-  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return datos[0].valor;
   }
 
@@ -32,14 +29,12 @@ function riesgopais(fecha) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
 
-  // Buscar la fecha exacta
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].fecha === fechaFormateada) {
       return datos[i].valor;
     }
   }
 
-  // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
     return d.fecha <= fechaFormateada;
   });
@@ -48,11 +43,9 @@ function riesgopais(fecha) {
     fechasMenores.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return fechasMenores[0].valor;
   }
 
-  // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
     return a.fecha.localeCompare(b.fecha);
   });

--- a/src/usa_stocks.js
+++ b/src/usa_stocks.js
@@ -9,59 +9,21 @@
  * @customfunction
  */
 function usa_stocks(symbol, value) {
-  // Consulta al API
-  var url = 'https://data912.com/live/usa_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Normalizo entradas
-  var simbolo = symbol.toString().toUpperCase().trim();
-  var atributo = value.toString().toLowerCase().trim();
-  
-  // Valores permitidos
-  var atributosPermitidos = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Verificar si el atributo es válido
-  if (!atributosPermitidos.includes(atributo)) {
-    throw new Error("Atributo inválido: '" + value + "'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change.");
-  }
-  
-  // Buscar el símbolo solicitado
-  for (var i = 0; i < datos.length; i++) {
-    if (datos[i].symbol === simbolo) {
-      return datos[i][atributo];
-    }
-  }
-  
-  // Si no se encontró el símbolo
-  throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en la lista de acciones estadounidenses disponibles.");
+  return panelCotizacion(
+    'https://data912.com/live/usa_stocks',
+    symbol,
+    value,
+    'acciones estadounidenses',
+    'panel:usa_stocks'
+  );
 }
 
 /**
  * Obtiene la lista completa de acciones de Estados Unidos desde la API.
- * 
- * @return Un arreglo bidimensional con todas las acciones estadounidenses y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
+ *
+ * @return Un arreglo bidimensional con todas las acciones y sus propiedades (symbol, c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change)
  * @customfunction
  */
 function usa_stocksLista() {
-  // Consulta al API
-  var url = 'https://data912.com/live/usa_stocks';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
-  
-  // Definir las columnas que queremos mostrar
-  var columnas = ['symbol', 'c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
-  
-  // Crear el arreglo bidimensional comenzando con los encabezados
-  var resultado = [columnas];
-  
-  // Agregar cada acción como una fila
-  datos.forEach(function(usaStock) {
-    var fila = columnas.map(function(columna) {
-      return usaStock[columna];
-    });
-    resultado.push(fila);
-  });
-  
-  return resultado;
+  return panelLista('https://data912.com/live/usa_stocks', 'panel:usa_stocks');
 }

--- a/src/uva.js
+++ b/src/uva.js
@@ -6,22 +6,19 @@
  * @customfunction
  */
 function uva(fecha) {
-  // Consulta al API
-  var url = 'https://api.argentinadatos.com/v1/finanzas/indices/uva';
-  var respuesta = UrlFetchApp.fetch(url);
-  var datos = JSON.parse(respuesta.getContentText());
+  var datos = fetchJson('https://api.argentinadatos.com/v1/finanzas/indices/uva', {
+    cacheKey: 'api:ad:uva',
+    cacheTtlSeconds: 300
+  });
 
   if (!datos || !datos.length) {
     throw new Error("No se recibieron datos de UVA desde la API.");
   }
 
-  // Si no se proporciona fecha, devolver el valor más reciente
-  // Comparar strings ISO (YYYY-MM-DD) evita desfases UTC de new Date(iso)
   if (!fecha) {
     datos.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return datos[0].valor;
   }
 
@@ -32,14 +29,12 @@ function uva(fecha) {
     throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
   }
 
-  // Buscar la fecha exacta
   for (var i = 0; i < datos.length; i++) {
     if (datos[i].fecha === fechaFormateada) {
       return datos[i].valor;
     }
   }
 
-  // Si no se encuentra la fecha exacta, buscar la fecha más cercana anterior
   var fechasMenores = datos.filter(function(d) {
     return d.fecha <= fechaFormateada;
   });
@@ -48,11 +43,9 @@ function uva(fecha) {
     fechasMenores.sort(function(a, b) {
       return b.fecha.localeCompare(a.fecha);
     });
-
     return fechasMenores[0].valor;
   }
 
-  // Si no hay fechas anteriores, devolver el dato más antiguo
   datos.sort(function(a, b) {
     return a.fecha.localeCompare(b.fecha);
   });

--- a/tests/all-in-one.test.js
+++ b/tests/all-in-one.test.js
@@ -12,6 +12,7 @@ global.Logger = {
 const {
   caucionColocadora,
   caucionTomadora,
+  calcularCaucion,
 } = require("./test-wrapper");
 
 describe("caucionColocadora", () => {
@@ -42,6 +43,19 @@ describe("caucionTomadora", () => {
 
     expect(typeof resultado).toBe("number");
     expect(resultado).toBeGreaterThan(importeBruto);
+  });
+});
+
+describe("calcularCaucion validación", () => {
+  test("rechaza dias === 0", () => {
+    expect(() => calcularCaucion(0, 1.2, 1000000)).toThrow("no puede ser 0");
+  });
+});
+
+describe("acciones validación", () => {
+  test("símbolo vacío lanza error legible", () => {
+    const { acciones } = require("./test-wrapper");
+    expect(() => acciones("", "c")).toThrow("Símbolo no proporcionado");
   });
 });
 

--- a/tests/dolar.test.js
+++ b/tests/dolar.test.js
@@ -15,12 +15,17 @@ describe("dolar", () => {
         createResponse([
           { casa: "blue", compra: null, venta: 1200 },
           { casa: "oficial", compra: 900, venta: 950 },
+          { casa: "bolsa", compra: 1000, venta: 1010 },
+          { casa: "contadoconliqui", compra: 1020, venta: 1030 },
         ])
       ),
     };
     global.Utilities = {};
     global.DriveApp = {};
     global.Logger = { log: jest.fn() };
+    global.CacheService = {
+      getScriptCache: () => ({ get: () => null, put: () => {} }),
+    };
     ({ dolar } = require("./test-wrapper"));
   });
 
@@ -29,6 +34,7 @@ describe("dolar", () => {
     delete global.Utilities;
     delete global.DriveApp;
     delete global.Logger;
+    delete global.CacheService;
   });
 
   test("promedio usa venta cuando compra es null", () => {
@@ -37,5 +43,21 @@ describe("dolar", () => {
 
   test("promedio calcula correctamente con compra y venta", () => {
     expect(dolar("oficial", "promedio")).toBe(925);
+  });
+
+  test("alias mep resuelve a bolsa", () => {
+    expect(dolar("mep", "venta")).toBe(1010);
+  });
+
+  test("alias ccl resuelve a contadoconliqui", () => {
+    expect(dolar("ccl", "compra")).toBe(1020);
+  });
+
+  test("operacion por defecto es venta", () => {
+    expect(dolar("blue")).toBe(1200);
+  });
+
+  test("tipo vacío lanza error legible", () => {
+    expect(() => dolar("", "venta")).toThrow("Tipo no proporcionado");
   });
 });

--- a/tests/dolar_historico.test.js
+++ b/tests/dolar_historico.test.js
@@ -1,0 +1,69 @@
+function createResponse(statusCode, body) {
+  return {
+    getResponseCode: () => statusCode,
+    getContentText: () => JSON.stringify(body),
+  };
+}
+
+describe("dolar_historico", () => {
+  let dolar_historico;
+  let fetchMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    fetchMock = jest.fn();
+    global.UrlFetchApp = { fetch: fetchMock };
+    global.Utilities = {
+      formatDate: () => "2023-01-15",
+    };
+    global.DriveApp = {};
+    global.Logger = { log: jest.fn() };
+    global.CacheService = {
+      getScriptCache: () => ({ get: () => null, put: () => {} }),
+    };
+
+    ({ dolar_historico } = require("./test-wrapper"));
+  });
+
+  afterEach(() => {
+    delete global.UrlFetchApp;
+    delete global.Utilities;
+    delete global.DriveApp;
+    delete global.Logger;
+    delete global.CacheService;
+  });
+
+  test("usa endpoint filtrado por casa y fecha", () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, {
+        casa: "blue",
+        compra: 365,
+        venta: 369,
+        fecha: "2023-01-15",
+      })
+    );
+
+    const result = dolar_historico("blue", "2023-01-15", "venta");
+
+    expect(result).toBe(369);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain("/dolares/blue/2023/01/15");
+    expect(fetchMock.mock.calls[0][0]).not.toMatch(/\/dolares$/);
+  });
+
+  test("acepta alias mep y fecha DD/MM/YYYY", () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, {
+        casa: "bolsa",
+        compra: 100,
+        venta: 101,
+        fecha: "2023-01-15",
+      })
+    );
+
+    const result = dolar_historico("mep", "15/01/2023", "compra");
+
+    expect(result).toBe(100);
+    expect(fetchMock.mock.calls[0][0]).toContain("/dolares/bolsa/2023/01/15");
+  });
+});

--- a/tests/fci.test.js
+++ b/tests/fci.test.js
@@ -104,6 +104,23 @@ describe("fci", () => {
     expect(fetchMock.mock.calls[0][0]).toContain("/rentaMixta/ultimo");
   });
 
+  test("match case-insensitive del nombre del fondo", () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, [
+        {
+          fondo: "Cocos Rendimiento - Clase A",
+          vcp: 111,
+          ccp: 100,
+          patrimonio: 1000,
+        },
+      ])
+    );
+
+    const result = fci("rentaMixta", "cocos rendimiento - clase a");
+
+    expect(result).toBe(111);
+  });
+
   test("acepta retornoTotal y consulta su endpoint", () => {
     fetchMock.mockReturnValue(
       createResponse(200, [

--- a/tests/http.test.js
+++ b/tests/http.test.js
@@ -1,0 +1,67 @@
+function createResponse(statusCode, body) {
+  return {
+    getResponseCode: () => statusCode,
+    getContentText: () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+describe("fetchJson", () => {
+  let fetchJson;
+  let fetchMock;
+  let cacheStore;
+
+  beforeEach(() => {
+    jest.resetModules();
+    cacheStore = new Map();
+    fetchMock = jest.fn();
+
+    global.UrlFetchApp = { fetch: fetchMock };
+    global.Utilities = {};
+    global.DriveApp = {};
+    global.Logger = { log: jest.fn() };
+    global.CacheService = {
+      getScriptCache: () => ({
+        get: (key) => (cacheStore.has(key) ? cacheStore.get(key) : null),
+        put: (key, value) => {
+          cacheStore.set(key, value);
+        },
+      }),
+    };
+
+    ({ fetchJson } = require("./test-wrapper"));
+  });
+
+  afterEach(() => {
+    delete global.UrlFetchApp;
+    delete global.Utilities;
+    delete global.DriveApp;
+    delete global.Logger;
+    delete global.CacheService;
+  });
+
+  test("devuelve JSON en respuesta 200", () => {
+    fetchMock.mockReturnValue(createResponse(200, { ok: true }));
+    expect(fetchJson("https://example.com/data")).toEqual({ ok: true });
+  });
+
+  test("lanza error en HTTP 500", () => {
+    fetchMock.mockReturnValue(createResponse(500, { message: "boom" }));
+    expect(() => fetchJson("https://example.com/data")).toThrow("Error HTTP 500");
+  });
+
+  test("cache hit no vuelve a llamar UrlFetchApp", () => {
+    fetchMock.mockReturnValue(createResponse(200, { n: 1 }));
+    const opts = { cacheKey: "t:1", cacheTtlSeconds: 60 };
+
+    expect(fetchJson("https://example.com/data", opts)).toEqual({ n: 1 });
+    expect(fetchJson("https://example.com/data", opts)).toEqual({ n: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("skipCache ignora cache", () => {
+    fetchMock.mockReturnValue(createResponse(200, { n: 1 }));
+    fetchJson("https://example.com/data", { cacheKey: "t:2", cacheTtlSeconds: 60 });
+    fetchJson("https://example.com/data", { cacheKey: "t:2", skipCache: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/test-wrapper.js
+++ b/tests/test-wrapper.js
@@ -5,13 +5,31 @@ Este wrapper permite importar las funciones desde all-in-one.js en los tests, ad
 const fs = require('fs');
 const path = require('path');
 
-// Crear un contexto global para ejecutar el script
+function createMemoryCache() {
+  const store = new Map();
+  return {
+    get: (key) => (store.has(key) ? store.get(key) : null),
+    put: (key, value) => {
+      store.set(key, value);
+    },
+    remove: (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+// Cache en memoria por carga del wrapper (un Map compartido en este contexto)
+const memoryCache = createMemoryCache();
+
 const context = {
   CONSTANTS: {},
   UrlFetchApp: global.UrlFetchApp,
   Utilities: global.Utilities,
   DriveApp: global.DriveApp || {},
   Logger: global.Logger || {},
+  CacheService: global.CacheService || {
+    getScriptCache: () => memoryCache,
+  },
   console: console
 };
 
@@ -32,6 +50,7 @@ const script = new Function('context', `
       bonosLista,
       caucionColocadora,
       caucionTomadora,
+      calcularCaucion,
       cedear,
       criptoya,
       crypto,
@@ -41,6 +60,7 @@ const script = new Function('context', `
       formatearFechaISO,
       parsearFechaLocal,
       obtenerComponentesFecha,
+      fetchJson,
       fci,
       fciLista,
       inflacion,


### PR DESCRIPTION
## Summary

Infraestructura y fixes de uso posteriores al P0 (#20):

- **`fetchJson` + `CacheService`**: todas las APIs pasan por un helper con `muteHttpExceptions`, chequeo de status y cache opcional (TTL 60–300s; payloads grandes se omiten).
- **`market_panel`**: elimina duplicación en acciones/bonos/letras/opciones/obligaciones/usa_stocks/cedears live.
- **`dolar_historico`**: endpoint filtrado `.../dolares/{casa}/{Y}/{M}/{D}` en lugar de bajar toda la serie.
- **Aliases**: `mep`→bolsa, `ccl`→contadoconliqui; operación por defecto `venta`.
- **Validaciones** de args vacíos; **FCI** match case-insensitive; **caución** rechaza `dias === 0`.
- **CI** (`.github/workflows/test.yml`): build + diff de `all-in-one.js` + tests.
- Docs: DOLAR, DOLAR_HISTORICO, CEDEAR (formatos de ratio), README, AGENTS.

## Test plan

- [x] `npm run build && npm test` — 36 tests green
- [x] `fetchJson` cache hit no re-fetch
- [x] `dolar_historico("blue","2023-01-15")` URL filtrada
- [x] `dolar("mep")` / `dolar("ccl")` aliases
- [x] `acciones("")` error legible
- [x] `calcularCaucion(0, …)` lanza
- [x] FCI case-insensitive

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor of how every sheet function fetches data; behavior changes (dólar histórico API, aliases, cache staleness) affect many user-facing formulas.
> 
> **Overview**
> Introduces **`fetchJson`** with optional **`CacheService`** caching (TTL per endpoint, ~90KB cap) and routes most external APIs through it instead of raw `UrlFetchApp` calls. **`panelCotizacion` / `panelLista`** in `market_panel.js` replace duplicated data912 logic across acciones, bonos, letras, opciones, obligaciones, CEDEARs live, and USA stocks.
> 
> **`dolar` / `dolar_historico`** gain **mep→bolsa** and **ccl→contadoconliqui** aliases, default **`venta`**, and historical quotes now hit ArgentinaDatos’ **per-casa/date URL** (not the full series). **`fci`** adds case-insensitive name matching; **`caucion`** rejects **`dias === 0`**; several functions validate empty arguments.
> 
> **CI** (`.github/workflows/test.yml`) runs **`npm ci`**, **`build`**, **`git diff --exit-code all-in-one.js`**, and **`npm test`**. **`build.js`** drops the generation timestamp for a deterministic bundle. New unit tests cover **`fetchJson`**, dólar aliases/historico, FCI, and caución; **`test-wrapper`** mocks **`CacheService`**.
> 
> Docs and **AGENTS.md** describe the new modules, caching, and commit expectations for **`all-in-one.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1d8c3eb9fafc0e5c3016105830ce806f153981a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->