### PR TITLE
docs: GitHub Pages — landing del proyecto

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 Scripts de Apps Script que añaden a tu Google Sheet funciones típicas para el día a día de un Argentino de bien.
 
+🌐 **Documentación y guía de uso:** [ferminrp.github.io/google-sheets-argento](https://ferminrp.github.io/google-sheets-argento/)
+
 [![Invitame un café en cafecito.app](https://cdn.cafecito.app/imgs/buttons/button_1.svg)](https://cafecito.app/ferminrp)
 
 ## Instalación
 
-Puedes utilizar el archivo `all-in-one.js` que incluye todas las funciones combinadas para una instalación simplificada.
+1. Abrí tu Google Sheet → **Extensiones → Apps Script**
+2. Pegá el contenido de [`all-in-one.js`](https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/all-in-one.js) (archivo único con todas las funciones)
+3. Guardá y volvé a la hoja
+4. Probá: `=dolar("blue")` (la primera vez Google pide autorizar el script)
+
+Guía paso a paso, catálogo de fórmulas y fuentes de datos: **[sitio web](https://ferminrp.github.io/google-sheets-argento/)**.
 
 ## Documentación de Funciones
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Sitio web (GitHub Pages)
+
+Esta carpeta es la **landing pública** del proyecto:
+
+**https://ferminrp.github.io/google-sheets-argento/**
+
+## Contenido
+
+| Archivo | Rol |
+|---------|-----|
+| `index.html` | Landing: qué es, instalación, uso, catálogo, fuentes, FAQ |
+| `styles.css` | Estilos (light / dark con `prefers-color-scheme`) |
+| `script.js` | Menú mobile, nav activa, copiar código |
+| `favicon.svg` | Icono |
+
+La documentación detallada de cada función sigue en [`../doc/`](../doc/) del repo (no se duplica acá).
+
+## Activar Pages en el repo
+
+1. GitHub → **Settings → Pages**
+2. Source: **Deploy from a branch**
+3. Branch: `main` · Folder: `/docs`
+4. Save
+
+Opcional: homepage del repo → `https://ferminrp.github.io/google-sheets-argento/`
+
+## Vista local
+
+```bash
+cd docs
+python3 -m http.server 8080
+# abrir http://localhost:8080
+```
+
+No hay build ni dependencias npm para el sitio.

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="7" fill="#0B3D91"/>
+  <rect x="6" y="7" width="20" height="18" rx="2" fill="#F7F5F0"/>
+  <rect x="6" y="7" width="20" height="5" rx="2" fill="#74ACDF"/>
+  <path d="M10 16h5M10 19h8M10 22h6" stroke="#0B3D91" stroke-width="1.6" stroke-linecap="round"/>
+  <circle cx="22" cy="21" r="3.2" fill="#74ACDF"/>
+  <path d="M22 19.6v2.8M20.6 21h2.8" stroke="#0B3D91" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,622 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Google Sheets Argento — Funciones financieras para Argentina</title>
+  <meta name="description" content="Funciones de Google Apps Script para cotizaciones de dólar, acciones, bonos, CEDEARs, inflación, crypto y más, directo en tu Google Sheet." />
+  <meta name="theme-color" content="#0b3d91" />
+  <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+  <meta property="og:title" content="Google Sheets Argento" />
+  <meta property="og:description" content="Cotizaciones y datos financieros argentinos en Google Sheets, con fórmulas simples." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ferminrp.github.io/google-sheets-argento/" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-nav">
+    <div class="wrap">
+      <a class="brand" href="#inicio">
+        <img src="favicon.svg" alt="" width="28" height="28" />
+        Sheets Argento
+      </a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="nav-menu">
+        Menú
+      </button>
+      <ul class="nav-links" id="nav-menu">
+        <li><a href="#que-hace">Qué hace</a></li>
+        <li><a href="#instalacion">Instalar</a></li>
+        <li><a href="#uso">Uso</a></li>
+        <li><a href="#funciones">Funciones</a></li>
+        <li><a href="#fuentes">Fuentes</a></li>
+        <li><a href="#faq">FAQ</a></li>
+      </ul>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" id="inicio">
+      <div class="wrap">
+        <div class="hero-badges">
+          <span class="badge">Open source · Gratis</span>
+          <span class="badge">Google Apps Script</span>
+          <span class="badge">Hecho para Argentina</span>
+        </div>
+        <h1>Google Sheets Argento</h1>
+        <p class="hero-sub">
+          Funciones listas para pegar en tu planilla: dólar, mercado argentino,
+          CEDEARs, inflación, UVA, crypto y más. Sin add-ons de pago.
+        </p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="#instalacion">Instalar en 2 minutos</a>
+          <a class="btn btn-secondary" href="https://github.com/ferminrp/google-sheets-argento" target="_blank" rel="noopener">Ver en GitHub</a>
+          <a class="btn btn-ghost" href="https://cafecito.app/ferminrp" target="_blank" rel="noopener">Invitame un cafecito</a>
+        </div>
+
+        <div class="hero-demo" aria-label="Ejemplo de fórmulas en una hoja">
+          <div class="hero-demo-bar">
+            <span class="dot" aria-hidden="true"></span>
+            <span class="dot" aria-hidden="true"></span>
+            <span class="dot" aria-hidden="true"></span>
+            Mi planilla · Google Sheets
+          </div>
+          <table class="sheet-table">
+            <thead>
+              <tr>
+                <th>Concepto</th>
+                <th>Fórmula</th>
+                <th>Resultado</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="cell-label">Dólar blue (venta)</td>
+                <td class="cell-formula">=dolar("blue")</td>
+                <td class="cell-value">1.250,00</td>
+              </tr>
+              <tr>
+                <td class="cell-label">MEP</td>
+                <td class="cell-formula">=dolar("mep";"venta")</td>
+                <td class="cell-value">1.180,50</td>
+              </tr>
+              <tr>
+                <td class="cell-label">Galicia (precio)</td>
+                <td class="cell-formula">=acciones("GGAL";"c")</td>
+                <td class="cell-value">6.420,00</td>
+              </tr>
+              <tr>
+                <td class="cell-label">Riesgo país</td>
+                <td class="cell-formula">=riesgopais()</td>
+                <td class="cell-value">1.245</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="disclaimer" style="margin-top: 1rem;">
+          Los valores de la tabla son ilustrativos. Las fórmulas traen datos en vivo desde APIs públicas.
+        </p>
+      </div>
+    </section>
+
+    <section class="section" id="que-hace">
+      <div class="wrap">
+        <h2>Qué hace</h2>
+        <p class="section-lead">
+          Un script de Apps Script que agrega funciones personalizadas a tu Google Sheet.
+          Escribís una fórmula y la celda se llena con datos financieros de Argentina.
+        </p>
+        <div class="cards">
+          <article class="card">
+            <h3>Dólar y BCRA</h3>
+            <p>Blue, oficial, MEP, CCL, tarjeta, histórico y variables del BCRA.</p>
+            <code>=dolar("blue")</code>
+          </article>
+          <article class="card">
+            <h3>Mercado argentino</h3>
+            <p>Acciones, bonos, letras, opciones y obligaciones negociables.</p>
+            <code>=acciones("YPF";"c")</code>
+          </article>
+          <article class="card">
+            <h3>CEDEARs y USA</h3>
+            <p>Precios, ratios y paneles de CEDEARs y acciones de EE.UU.</p>
+            <code>=cedear("AAPL";"c")</code>
+          </article>
+          <article class="card">
+            <h3>Indicadores</h3>
+            <p>Inflación mensual, UVA y riesgo país, con fecha opcional.</p>
+            <code>=inflacion()</code>
+          </article>
+          <article class="card">
+            <h3>Crypto</h3>
+            <p>Precios spot y comparador por exchange (CriptoYa), más APYs.</p>
+            <code>=criptoya("BTC";"ARS")</code>
+          </article>
+          <article class="card">
+            <h3>Inversiones</h3>
+            <p>Plazos fijos, FCI y cálculo de cauciones tomadora/colocadora.</p>
+            <code>=plazofijo("Nacion")</code>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="instalacion">
+      <div class="wrap">
+        <h2>Cómo instalarlo</h2>
+        <p class="section-lead">
+          No hace falta Node, clasp ni extensiones de Chrome. Solo copiar un archivo en Apps Script.
+        </p>
+
+        <ol class="steps">
+          <li>
+            <div>
+              <h3>Abrí tu Google Sheet</h3>
+              <p>Creá una planilla nueva o usá una existente donde quieras las fórmulas.</p>
+            </div>
+          </li>
+          <li>
+            <div>
+              <h3>Entrá a Apps Script</h3>
+              <p>Menú <strong>Extensiones → Apps Script</strong>. Se abre el editor de Google.</p>
+            </div>
+          </li>
+          <li>
+            <div>
+              <h3>Pegá el código completo</h3>
+              <p>
+                Borrá el contenido por defecto del editor y pegá el archivo
+                <strong>all-in-one.js</strong> del repositorio (incluye todas las funciones).
+              </p>
+              <div class="step-actions">
+                <a class="btn btn-secondary" href="https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/all-in-one.js" target="_blank" rel="noopener">Abrir all-in-one.js (raw)</a>
+                <a class="btn btn-ghost" href="https://github.com/ferminrp/google-sheets-argento/blob/main/all-in-one.js" target="_blank" rel="noopener">Ver en GitHub</a>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div>
+              <h3>Guardá el proyecto</h3>
+              <p>Ctrl+S o ⌘+S. Podés renombrar el proyecto a “Sheets Argento” si querés.</p>
+            </div>
+          </li>
+          <li>
+            <div>
+              <h3>Volvé a la hoja y probá</h3>
+              <p>
+                La primera vez que uses una fórmula, Google pedirá <strong>autorizar</strong>
+                el script (acceso a servicios externos). Aceptá y listo.
+              </p>
+              <div class="code-block">
+                <pre>=dolar("blue")</pre>
+              </div>
+            </div>
+          </li>
+        </ol>
+
+        <div class="callout">
+          <strong>Tips de instalación</strong>
+          <ul>
+            <li>En Sheets con locale argentino, el separador de argumentos suele ser <code class="inline-code">;</code> (no coma).</li>
+            <li>No necesitás instalar nada en la compu: todo corre en la nube de Google.</li>
+            <li>Para actualizar, volvé a pegar el <code class="inline-code">all-in-one.js</code> más reciente del repo.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="uso">
+      <div class="wrap">
+        <h2>Cómo usarlo</h2>
+        <p class="section-lead">
+          Escribí las fórmulas en cualquier celda, igual que <code class="inline-code">=SUMA()</code>.
+          Algunas funciones devuelven un número; otras, tablas completas.
+        </p>
+
+        <div class="table-wrap">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>Fórmula</th>
+                <th>Qué devuelve</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>=dolar("blue")</code></td>
+                <td>Venta del dólar blue (default)</td>
+              </tr>
+              <tr>
+                <td><code>=dolar("mep";"venta")</code></td>
+                <td>MEP (alias de bolsa)</td>
+              </tr>
+              <tr>
+                <td><code>=dolar("ccl";"promedio")</code></td>
+                <td>CCL promedio (alias de contadoconliqui)</td>
+              </tr>
+              <tr>
+                <td><code>=dolar_historico("blue";"15/01/2024")</code></td>
+                <td>Blue en una fecha (también acepta YYYY-MM-DD)</td>
+              </tr>
+              <tr>
+                <td><code>=acciones("GGAL";"c")</code></td>
+                <td>Precio de Galicia</td>
+              </tr>
+              <tr>
+                <td><code>=accionesLista()</code></td>
+                <td>Tabla con todo el panel de acciones AR</td>
+              </tr>
+              <tr>
+                <td><code>=bonos("AL30";"pct_change")</code></td>
+                <td>Variación diaria del AL30</td>
+              </tr>
+              <tr>
+                <td><code>=cedear("AAPL";"c")</code></td>
+                <td>Precio del CEDEAR de Apple</td>
+              </tr>
+              <tr>
+                <td><code>=cedear("AAPL";"ratio")</code></td>
+                <td>Ratio CEDEAR / acción</td>
+              </tr>
+              <tr>
+                <td><code>=inflacion()</code></td>
+                <td>Último dato de inflación mensual</td>
+              </tr>
+              <tr>
+                <td><code>=uva()</code></td>
+                <td>Valor actual del UVA</td>
+              </tr>
+              <tr>
+                <td><code>=riesgopais()</code></td>
+                <td>Riesgo país más reciente</td>
+              </tr>
+              <tr>
+                <td><code>=bcra(1)</code></td>
+                <td>Reservas internacionales (variable BCRA id 1)</td>
+              </tr>
+              <tr>
+                <td><code>=criptoya("BTC";"ARS")</code></td>
+                <td>Mejor precio BTC/ARS entre exchanges</td>
+              </tr>
+              <tr>
+                <td><code>=crypto("BTC")</code></td>
+                <td>Spot BTC en USD (Coinbase)</td>
+              </tr>
+              <tr>
+                <td><code>=plazofijo()</code></td>
+                <td>Mejor TNA de plazo fijo (clientes)</td>
+              </tr>
+              <tr>
+                <td><code>=fci("mercadoDinero";"Balanz Money Market USD - Clase A")</code></td>
+                <td>Valor cuotaparte del FCI</td>
+              </tr>
+              <tr>
+                <td><code>=caucionColocadora(30; 40; 1000000)</code></td>
+                <td>Resultado de una caución colocadora</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="callout">
+          <strong>Atributos de paneles de mercado</strong>
+          <ul>
+            <li><code class="inline-code">c</code> precio · <code class="inline-code">v</code> volumen · <code class="inline-code">pct_change</code> variación %</li>
+            <li><code class="inline-code">px_bid</code> / <code class="inline-code">px_ask</code> bid/ask · <code class="inline-code">q_bid</code> / <code class="inline-code">q_ask</code> cantidades · <code class="inline-code">q_op</code> operaciones</li>
+            <li>Vale para acciones, bonos, letras, opciones, ONs, CEDEARs y USA stocks</li>
+          </ul>
+        </div>
+
+        <h3 style="margin-top: 2rem;">Cuándo se actualizan los datos</h3>
+        <p style="color: var(--ink-muted); max-width: 55ch;">
+          Google Sheets recalcula al abrir la hoja o al editar celdas.
+          Podés forzar con <strong>Ctrl+R</strong> (Windows) o <strong>⌘+R</strong> (Mac),
+          o en Archivo → Configuración → Cálculo.
+          Las cotizaciones live usan cache de ~60&nbsp;s en Apps Script para no saturar las APIs.
+        </p>
+      </div>
+    </section>
+
+    <section class="section" id="funciones">
+      <div class="wrap">
+        <h2>Catálogo de funciones</h2>
+        <p class="section-lead">
+          Cada ítem enlaza a la documentación detallada en el repositorio
+          (parámetros, errores y más ejemplos).
+        </p>
+
+        <div class="catalog-group">
+          <h3>Cotizaciones y tipos de cambio</h3>
+          <div class="catalog-list">
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/DOLAR.md" target="_blank" rel="noopener">dolar</a>
+              <span class="desc">Cotizaciones actuales (blue, oficial, MEP, CCL…)</span>
+              <span class="example">=dolar("blue";"venta")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/DOLAR_HISTORICO.md" target="_blank" rel="noopener">dolar_historico</a>
+              <span class="desc">Cotización de un tipo de dólar en una fecha</span>
+              <span class="example">=dolar_historico("blue";"2024-01-15")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/BCRA.md" target="_blank" rel="noopener">bcra</a>
+              <span class="desc">Variables económicas del Banco Central</span>
+              <span class="example">=bcra(1)</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="catalog-group">
+          <h3>Instrumentos financieros argentinos</h3>
+          <div class="catalog-list">
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/ACCIONES.md" target="_blank" rel="noopener">acciones</a>
+              <span class="desc">Panel de acciones BYMA (+ accionesLista)</span>
+              <span class="example">=acciones("PAMP";"c")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/BONOS.md" target="_blank" rel="noopener">bonos</a>
+              <span class="desc">Bonos soberanos y panel completo</span>
+              <span class="example">=bonos("AL30";"c")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/LETRAS.md" target="_blank" rel="noopener">letras</a>
+              <span class="desc">Letras del tesoro</span>
+              <span class="example">=letras("S31L25";"c")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/OPCIONES.md" target="_blank" rel="noopener">opciones</a>
+              <span class="desc">Opciones sobre acciones argentinas</span>
+              <span class="example">=opciones("GFGC550.AB";"c")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/OBLIGACIONES.md" target="_blank" rel="noopener">obligaciones</a>
+              <span class="desc">Obligaciones negociables</span>
+              <span class="example">=obligaciones("YPFD";"c")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CAUCION.md" target="_blank" rel="noopener">caucion</a>
+              <span class="desc">Cálculo de cauciones tomadora y colocadora</span>
+              <span class="example">=caucionColocadora(7; 50; 500000)</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="catalog-group">
+          <h3>Instrumentos internacionales</h3>
+          <div class="catalog-list">
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CEDEAR.md" target="_blank" rel="noopener">cedear</a>
+              <span class="desc">CEDEARs: precio, nombre, ratio (+ cedearLista)</span>
+              <span class="example">=cedear("MSFT";"name")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/USA_STOCKS.md" target="_blank" rel="noopener">usa_stocks</a>
+              <span class="desc">Acciones de EE.UU. en panel data912</span>
+              <span class="example">=usa_stocks("AAPL";"c")</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="catalog-group">
+          <h3>Indicadores económicos</h3>
+          <div class="catalog-list">
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/INFLACION.md" target="_blank" rel="noopener">inflacion</a>
+              <span class="desc">IPC / inflación mensual</span>
+              <span class="example">=inflacion("2024-03-01")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/UVA.md" target="_blank" rel="noopener">uva</a>
+              <span class="desc">Índice UVA</span>
+              <span class="example">=uva()</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/RIESGOPAIS.md" target="_blank" rel="noopener">riesgopais</a>
+              <span class="desc">Riesgo país EMBI</span>
+              <span class="example">=riesgopais()</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="catalog-group">
+          <h3>Criptomonedas</h3>
+          <div class="catalog-list">
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CRYPTO.md" target="_blank" rel="noopener">crypto</a>
+              <span class="desc">Precio spot vía Coinbase</span>
+              <span class="example">=crypto("ETH";"USD")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CRIPTOYA.md" target="_blank" rel="noopener">criptoya</a>
+              <span class="desc">Comparador de precios por exchange</span>
+              <span class="example">=criptoya("USDT";"ARS";1000)</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/RENDIMIENTOS.md" target="_blank" rel="noopener">rendimientos</a>
+              <span class="desc">APY de crypto en proveedores AR</span>
+              <span class="example">=rendimientos("USDT")</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="catalog-group">
+          <h3>Inversiones y plazos fijos</h3>
+          <div class="catalog-list">
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/PLAZOFIJO.md" target="_blank" rel="noopener">plazofijo</a>
+              <span class="desc">TNA de plazos fijos por banco</span>
+              <span class="example">=plazofijo("Galicia";"cliente")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/FCI.md" target="_blank" rel="noopener">fci</a>
+              <span class="desc">Fondos comunes: vcp, ccp, patrimonio</span>
+              <span class="example">=fci("rentaFija";"Pionero Renta")</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="fuentes">
+      <div class="wrap">
+        <h2>Fuentes de datos</h2>
+        <p class="section-lead">
+          El proyecto no aloja cotizaciones propias: consulta APIs públicas y
+          open data mantenidas por la comunidad y organismos.
+        </p>
+
+        <div class="table-wrap">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>Fuente</th>
+                <th>Para qué se usa</th>
+                <th>Referencia</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="fn-name">DolarAPI</td>
+                <td>Cotizaciones live de dólar (<code>dolar</code>)</td>
+                <td><a href="https://dolarapi.com" target="_blank" rel="noopener">dolarapi.com</a></td>
+              </tr>
+              <tr>
+                <td class="fn-name">Argentina Datos</td>
+                <td>Inflación, UVA, FCI, dólar histórico, riesgo país, plazos fijos, rendimientos</td>
+                <td>
+                  <a href="https://argentinadatos.com/" target="_blank" rel="noopener">argentinadatos.com</a>
+                  · <a href="https://github.com/enzonotario/" target="_blank" rel="noopener">@enzonotario</a>
+                </td>
+              </tr>
+              <tr>
+                <td class="fn-name">data912</td>
+                <td>Paneles live: acciones, bonos, letras, opciones, ONs, CEDEARs, USA stocks</td>
+                <td>
+                  <a href="https://data912.com" target="_blank" rel="noopener">data912.com</a>
+                  · <a href="https://x.com/JohnGalt_is_www" target="_blank" rel="noopener">@JohnGalt_is_www</a>
+                </td>
+              </tr>
+              <tr>
+                <td class="fn-name">CriptoYa</td>
+                <td>Comparador de precios crypto por exchange</td>
+                <td><a href="https://criptoya.com/" target="_blank" rel="noopener">criptoya.com</a></td>
+              </tr>
+              <tr>
+                <td class="fn-name">Coinbase</td>
+                <td>Spot de criptomonedas (<code>crypto</code>)</td>
+                <td><a href="https://www.coinbase.com/" target="_blank" rel="noopener">api.coinbase.com</a></td>
+              </tr>
+              <tr>
+                <td class="fn-name">BCRA</td>
+                <td>Variables monetarias oficiales</td>
+                <td><a href="https://www.bcra.gob.ar/" target="_blank" rel="noopener">bcra.gob.ar</a></td>
+              </tr>
+              <tr>
+                <td class="fn-name">cedears.json</td>
+                <td>Nombres y ratios de CEDEARs (repo)</td>
+                <td><a href="https://github.com/ferminrp/google-sheets-argento/blob/main/data/cedears.json" target="_blank" rel="noopener">data/cedears.json</a></td>
+              </tr>
+              <tr>
+                <td class="fn-name">Cálculo local</td>
+                <td>Cauciones (fórmulas + aranceles de referencia BYMA)</td>
+                <td><a href="https://github.com/ferminrp/google-sheets-argento/blob/main/src/caucion.js" target="_blank" rel="noopener">caucion.js</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p class="disclaimer">
+          Las cotizaciones dependen de terceros y pueden retrasarse o fallar si la API de origen
+          no responde. Esto <strong>no es consejo financiero</strong>. Verificá siempre con tu broker
+          o fuente oficial antes de operar.
+        </p>
+      </div>
+    </section>
+
+    <section class="section" id="faq">
+      <div class="wrap">
+        <h2>Preguntas frecuentes</h2>
+        <p class="section-lead">Cosas que suelen aparecer al instalar o usar las fórmulas.</p>
+
+        <div class="faq">
+          <details>
+            <summary>¿Es gratis?</summary>
+            <p>
+              Sí. El código es open source. Las APIs que usa también son públicas
+              (sujetas a los términos de cada proveedor). Podés invitar un
+              <a href="https://cafecito.app/ferminrp" target="_blank" rel="noopener">cafecito</a>
+              si te resulta útil.
+            </p>
+          </details>
+          <details>
+            <summary>¿Funciona sin internet?</summary>
+            <p>
+              No. Cada recálculo de fórmula hace (o lee del cache) un request a las APIs.
+              Si no hay red o la API cae, la celda muestra un error.
+            </p>
+          </details>
+          <details>
+            <summary>¿Por qué a veces el valor no cambia al toque?</summary>
+            <p>
+              Hay dos capas: el cache de Apps Script (~60&nbsp;s en cotizaciones live)
+              y el motor de recálculo de Google Sheets. Forzá con Ctrl/⌘+R o editá una celda.
+            </p>
+          </details>
+          <details>
+            <summary>¿Cómo actualizo el script?</summary>
+            <p>
+              Abrí de nuevo Apps Script, reemplazá el contenido por el
+              <a href="https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/all-in-one.js" target="_blank" rel="noopener">all-in-one.js</a>
+              actual del repo y guardá.
+            </p>
+          </details>
+          <details>
+            <summary>¿Puedo usar “mep” y “ccl” en vez de bolsa / contadoconliqui?</summary>
+            <p>
+              Sí. <code class="inline-code">mep</code> es alias de <code class="inline-code">bolsa</code>
+              y <code class="inline-code">ccl</code> / <code class="inline-code">contado</code> de
+              <code class="inline-code">contadoconliqui</code>.
+            </p>
+          </details>
+          <details>
+            <summary>Mi fórmula usa comas y no funciona</summary>
+            <p>
+              En muchas cuentas de Google en Argentina el separador de argumentos es
+              <strong>punto y coma</strong>:
+              <code class="inline-code">=dolar("blue";"venta")</code>.
+              Si tu hoja usa coma, probá con el locale de la planilla.
+            </p>
+          </details>
+          <details>
+            <summary>¿Puedo contribuir o reportar un bug?</summary>
+            <p>
+              Sí: abrí un issue o un PR en
+              <a href="https://github.com/ferminrp/google-sheets-argento" target="_blank" rel="noopener">GitHub</a>.
+              Para desarrollo local: <code class="inline-code">npm install</code>,
+              <code class="inline-code">npm run build</code>, <code class="inline-code">npm test</code>.
+            </p>
+          </details>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrap">
+      <div class="footer-brand">Google Sheets Argento</div>
+      <ul class="footer-links">
+        <li><a href="https://github.com/ferminrp/google-sheets-argento" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://github.com/ferminrp/google-sheets-argento/issues" target="_blank" rel="noopener">Issues</a></li>
+        <li><a href="https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/all-in-one.js" target="_blank" rel="noopener">all-in-one.js</a></li>
+        <li><a href="https://cafecito.app/ferminrp" target="_blank" rel="noopener">Cafecito</a></li>
+      </ul>
+      <p class="footer-note">
+        Hecho para argentinos de bien · Datos de DolarAPI, Argentina Datos, data912, CriptoYa, Coinbase y BCRA ·
+        No es consejo financiero.
+      </p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -290,7 +290,7 @@
                 <td>Valor cuotaparte del FCI</td>
               </tr>
               <tr>
-                <td><code>=caucionColocadora(30; 40; 1000000)</code></td>
+                <td><code>=caucionColocadora(30; 40%; 1000000)</code></td>
                 <td>Resultado de una caución colocadora</td>
               </tr>
             </tbody>
@@ -376,7 +376,7 @@
             <div class="catalog-item">
               <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CAUCION.md" target="_blank" rel="noopener">caucion</a>
               <span class="desc">Cálculo de cauciones tomadora y colocadora</span>
-              <span class="example">=caucionColocadora(7; 50; 500000)</span>
+              <span class="example">=caucionColocadora(7; 50%; 500000)</span>
             </div>
           </div>
         </div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,19 +1,6 @@
 (function () {
   'use strict';
 
-  var DOC_BASE =
-    'https://github.com/ferminrp/google-sheets-argento/blob/main/doc/';
-  var REPO = 'https://github.com/ferminrp/google-sheets-argento';
-  var RAW_ALL_IN_ONE =
-    'https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/all-in-one.js';
-
-  // Expose raw link for any UI that needs it
-  window.GSA = {
-    docBase: DOC_BASE,
-    repo: REPO,
-    rawAllInOne: RAW_ALL_IN_ONE,
-  };
-
   // ——— Mobile nav ———
   var toggle = document.querySelector('.nav-toggle');
   var links = document.querySelector('.nav-links');

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,112 @@
+(function () {
+  'use strict';
+
+  var DOC_BASE =
+    'https://github.com/ferminrp/google-sheets-argento/blob/main/doc/';
+  var REPO = 'https://github.com/ferminrp/google-sheets-argento';
+  var RAW_ALL_IN_ONE =
+    'https://raw.githubusercontent.com/ferminrp/google-sheets-argento/main/all-in-one.js';
+
+  // Expose raw link for any UI that needs it
+  window.GSA = {
+    docBase: DOC_BASE,
+    repo: REPO,
+    rawAllInOne: RAW_ALL_IN_ONE,
+  };
+
+  // ——— Mobile nav ———
+  var toggle = document.querySelector('.nav-toggle');
+  var links = document.querySelector('.nav-links');
+
+  if (toggle && links) {
+    toggle.addEventListener('click', function () {
+      var open = links.classList.toggle('is-open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+
+    links.querySelectorAll('a').forEach(function (a) {
+      a.addEventListener('click', function () {
+        links.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      });
+    });
+  }
+
+  // ——— Active section in nav ———
+  var sections = document.querySelectorAll('main section[id]');
+  var navAnchors = document.querySelectorAll('.nav-links a[href^="#"]');
+
+  function setActiveNav() {
+    var scrollY = window.scrollY + 80;
+    var current = null;
+
+    sections.forEach(function (section) {
+      if (section.offsetTop <= scrollY) {
+        current = section.id;
+      }
+    });
+
+    navAnchors.forEach(function (a) {
+      var href = a.getAttribute('href');
+      var match = href === '#' + current;
+      if (match) {
+        a.setAttribute('aria-current', 'true');
+      } else {
+        a.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  if (sections.length && navAnchors.length) {
+    window.addEventListener('scroll', setActiveNav, { passive: true });
+    setActiveNav();
+  }
+
+  // ——— Copy buttons ———
+  document.querySelectorAll('.code-block').forEach(function (block) {
+    var pre = block.querySelector('pre');
+    if (!pre) return;
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'copy-btn';
+    btn.textContent = 'Copiar';
+    btn.setAttribute('aria-label', 'Copiar código');
+    block.appendChild(btn);
+
+    btn.addEventListener('click', function () {
+      var text = pre.textContent || '';
+      function done() {
+        btn.textContent = 'Copiado';
+        btn.classList.add('copied');
+        setTimeout(function () {
+          btn.textContent = 'Copiar';
+          btn.classList.remove('copied');
+        }, 1600);
+      }
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done).catch(fallbackCopy);
+      } else {
+        fallbackCopy();
+      }
+
+      function fallbackCopy() {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand('copy');
+          done();
+        } catch (e) {
+          btn.textContent = 'Error';
+        }
+        document.body.removeChild(ta);
+      }
+    });
+  });
+})();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,818 @@
+/* Google Sheets Argento — GitHub Pages */
+
+:root {
+  --bg: #f4f1ea;
+  --bg-elevated: #fffcf7;
+  --bg-muted: #eae4d8;
+  --ink: #152033;
+  --ink-muted: #4a5568;
+  --border: #d5cdbf;
+  --accent: #0b3d91;
+  --accent-soft: #74acdf;
+  --accent-wash: rgba(116, 172, 223, 0.18);
+  --money: #1a6b45;
+  --money-wash: rgba(26, 107, 69, 0.1);
+  --danger: #9b2c2c;
+  --shadow: 0 1px 2px rgba(21, 32, 51, 0.06), 0 8px 24px rgba(21, 32, 51, 0.06);
+  --radius: 12px;
+  --radius-sm: 8px;
+  --max: 920px;
+  --font: "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  --mono: "SF Mono", "Cascadia Code", "Consolas", "Liberation Mono", ui-monospace, monospace;
+  --nav-h: 60px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1419;
+    --bg-elevated: #1a222d;
+    --bg-muted: #243040;
+    --ink: #eef2f7;
+    --ink-muted: #a0aec0;
+    --border: #2f3b4d;
+    --accent: #74acdf;
+    --accent-soft: #4a8fc4;
+    --accent-wash: rgba(116, 172, 223, 0.12);
+    --money: #4ade80;
+    --money-wash: rgba(74, 222, 128, 0.1);
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.25);
+  }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--nav-h) + 16px);
+}
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Subtle grid texture */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  opacity: 0.4;
+  background-image:
+    linear-gradient(var(--border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black, transparent);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+a {
+  color: var(--accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+/* ——— Layout ——— */
+
+.wrap {
+  width: min(100% - 2rem, var(--max));
+  margin-inline: auto;
+}
+
+.section {
+  padding: 3.5rem 0;
+}
+
+.section + .section {
+  border-top: 1px solid var(--border);
+}
+
+.section h2 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 3vw, 1.85rem);
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+}
+
+.section-lead {
+  margin: 0 0 1.75rem;
+  color: var(--ink-muted);
+  max-width: 52ch;
+}
+
+/* ——— Nav ——— */
+
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  height: var(--nav-h);
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.site-nav .wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+  gap: 1rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 700;
+  color: var(--ink);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+}
+
+.brand:hover {
+  text-decoration: none;
+  color: var(--accent);
+}
+
+.brand img {
+  width: 28px;
+  height: 28px;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  display: block;
+  padding: 0.4rem 0.65rem;
+  color: var(--ink-muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  border-radius: 6px;
+}
+
+.nav-links a:hover,
+.nav-links a[aria-current="true"] {
+  color: var(--ink);
+  background: var(--accent-wash);
+  text-decoration: none;
+}
+
+.nav-toggle {
+  display: none;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--ink);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.65rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+@media (max-width: 760px) {
+  .nav-toggle {
+    display: block;
+  }
+
+  .nav-links {
+    display: none;
+    position: absolute;
+    top: var(--nav-h);
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    background: var(--bg-elevated);
+    border-bottom: 1px solid var(--border);
+    padding: 0.5rem;
+    box-shadow: var(--shadow);
+  }
+
+  .nav-links.is-open {
+    display: flex;
+  }
+
+  .nav-links a {
+    padding: 0.75rem 1rem;
+  }
+}
+
+/* ——— Hero ——— */
+
+.hero {
+  padding: 3.5rem 0 4rem;
+}
+
+.hero-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: 999px;
+  background: var(--accent-wash);
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+.hero h1 {
+  margin: 0 0 0.85rem;
+  font-size: clamp(2.1rem, 5.5vw, 3rem);
+  letter-spacing: -0.035em;
+  line-height: 1.1;
+  max-width: 16ch;
+}
+
+.hero-sub {
+  margin: 0 0 1.75rem;
+  font-size: 1.15rem;
+  color: var(--ink-muted);
+  max-width: 42ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.7rem 1.15rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+
+.btn:hover {
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+  .btn-primary {
+    color: #0f1419;
+  }
+}
+
+.btn-primary:hover {
+  filter: brightness(1.08);
+}
+
+.btn-secondary {
+  background: var(--bg-elevated);
+  color: var(--ink);
+  border-color: var(--border);
+  box-shadow: var(--shadow);
+}
+
+.btn-secondary:hover {
+  border-color: var(--accent-soft);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--ink-muted);
+  border-color: transparent;
+}
+
+.btn-ghost:hover {
+  color: var(--ink);
+  background: var(--accent-wash);
+}
+
+.hero-demo {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.hero-demo-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1rem;
+  background: var(--bg-muted);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.8rem;
+  color: var(--ink-muted);
+  font-weight: 500;
+}
+
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--border);
+}
+
+.dot:nth-child(1) { background: #e85d5d; }
+.dot:nth-child(2) { background: #e8c45d; }
+.dot:nth-child(3) { background: #5dc46e; }
+
+.sheet-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.sheet-table th,
+.sheet-table td {
+  padding: 0.65rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.sheet-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
+  font-weight: 600;
+  background: color-mix(in srgb, var(--bg-muted) 50%, transparent);
+}
+
+.sheet-table tr:last-child td {
+  border-bottom: none;
+}
+
+.sheet-table .cell-formula {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  color: var(--money);
+}
+
+.sheet-table .cell-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.sheet-table .cell-label {
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+}
+
+/* ——— Cards grid ——— */
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.15rem 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.card p {
+  margin: 0 0 0.85rem;
+  color: var(--ink-muted);
+  font-size: 0.92rem;
+}
+
+.card code,
+.inline-code {
+  font-family: var(--mono);
+  font-size: 0.82em;
+  background: var(--money-wash);
+  color: var(--money);
+  padding: 0.12em 0.4em;
+  border-radius: 4px;
+}
+
+/* ——— Steps ——— */
+
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  counter-reset: step;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.steps li {
+  counter-increment: step;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.15rem 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.steps li::before {
+  content: counter(step);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .steps li::before {
+    color: #0f1419;
+  }
+}
+
+.steps h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.05rem;
+}
+
+.steps p {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.95rem;
+}
+
+.steps .step-actions {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.callout {
+  margin-top: 1.5rem;
+  padding: 1rem 1.15rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--accent-wash);
+  font-size: 0.95rem;
+}
+
+.callout strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.callout ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--ink-muted);
+}
+
+/* ——— Code blocks ——— */
+
+.code-block {
+  position: relative;
+  margin: 0.75rem 0 0;
+  background: #152033;
+  color: #e8edf5;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+@media (prefers-color-scheme: dark) {
+  .code-block {
+    background: #0a0e14;
+    border: 1px solid var(--border);
+  }
+}
+
+.code-block pre {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.code-block .copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.3rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-family: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #c5d0e0;
+  cursor: pointer;
+}
+
+.code-block .copy-btn:hover,
+.code-block .copy-btn.copied {
+  background: rgba(116, 172, 223, 0.25);
+  color: #fff;
+}
+
+/* ——— Tables ——— */
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.data-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
+  background: var(--bg-muted);
+  white-space: nowrap;
+}
+
+.data-table tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table code {
+  font-family: var(--mono);
+  font-size: 0.84em;
+  white-space: nowrap;
+}
+
+.data-table .fn-name {
+  font-weight: 600;
+}
+
+/* ——— Catalog ——— */
+
+.catalog-group {
+  margin-bottom: 2rem;
+}
+
+.catalog-group:last-child {
+  margin-bottom: 0;
+}
+
+.catalog-group h3 {
+  margin: 0 0 0.85rem;
+  font-size: 1.1rem;
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.catalog-group h3::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.catalog-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.catalog-item {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.25rem;
+  padding: 0.9rem 1.1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+@media (min-width: 640px) {
+  .catalog-item {
+    grid-template-columns: minmax(140px, 180px) 1fr auto;
+    align-items: center;
+    gap: 1rem;
+  }
+}
+
+.catalog-item a {
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--accent);
+}
+
+.catalog-item a:hover {
+  text-decoration: underline;
+}
+
+.catalog-item .desc {
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+}
+
+.catalog-item .example {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--money);
+  background: var(--money-wash);
+  padding: 0.3rem 0.55rem;
+  border-radius: 6px;
+  justify-self: start;
+}
+
+/* ——— FAQ ——— */
+
+.faq {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.faq details {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.15rem 0;
+  box-shadow: var(--shadow);
+}
+
+.faq summary {
+  cursor: pointer;
+  padding: 0.85rem 1.1rem;
+  font-weight: 600;
+  list-style: none;
+}
+
+.faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq summary::before {
+  content: "+";
+  display: inline-block;
+  width: 1.2em;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.faq details[open] summary::before {
+  content: "−";
+}
+
+.faq details p {
+  margin: 0;
+  padding: 0 1.1rem 1rem 2.3rem;
+  color: var(--ink-muted);
+  font-size: 0.95rem;
+}
+
+/* ——— Sources disclaimer ——— */
+
+.disclaimer {
+  margin-top: 1.25rem;
+  font-size: 0.88rem;
+  color: var(--ink-muted);
+  padding: 0.85rem 1rem;
+  border-left: 3px solid var(--accent-soft);
+  background: var(--bg-elevated);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+/* ——— Footer ——— */
+
+.site-footer {
+  padding: 2.5rem 0 3rem;
+  border-top: 1px solid var(--border);
+  background: var(--bg-muted);
+}
+
+.site-footer .wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.footer-brand {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-links a {
+  color: var(--ink-muted);
+  text-decoration: none;
+  font-size: 0.92rem;
+}
+
+.footer-links a:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.footer-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+}
+
+/* ——— Utilities ——— */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.mt-0 { margin-top: 0; }
+.mb-0 { margin-bottom: 0; }


### PR DESCRIPTION
## Summary

Landing pública para el proyecto en GitHub Pages:

- **Qué es** y bloques de capacidades (dólar, mercado AR, CEDEARs, indicadores, crypto, inversiones)
- **Instalación** paso a paso con link raw a `all-in-one.js`
- **Uso** con tabla de fórmulas de ejemplo y tips de recálculo / `;`
- **Catálogo** de funciones con links a `doc/*.md`
- **Fuentes de datos** (DolarAPI, Argentina Datos, data912, CriptoYa, Coinbase, BCRA, etc.)
- **FAQ** y footer

Stack: HTML/CSS/JS vanilla en `docs/` (sin build). Dark mode via `prefers-color-scheme`.

## Después del merge

Activar Pages en el repo:

1. Settings → Pages → Deploy from a branch → `main` / `/docs`
2. Homepage del repo → `https://ferminrp.github.io/google-sheets-argento/`

```bash
gh api -X POST repos/ferminrp/google-sheets-argento/pages \
  -f build_type=legacy \
  -f 'source[branch]=main' \
  -f 'source[path]=/docs'
gh repo edit ferminrp/google-sheets-argento \
  --homepage "https://ferminrp.github.io/google-sheets-argento/"
```

## Test plan

- [ ] Abrir `docs/index.html` localmente (o `python3 -m http.server` en `docs/`)
- [ ] Revisar anclas del nav, menú mobile, botones Copiar
- [ ] Links a `all-in-one.js` raw y a `doc/*.md`
- [ ] Tras merge + activar Pages: URL del sitio responde 200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static site only; no changes to Apps Script or runtime behavior.
> 
> **Overview**
> Adds a **public GitHub Pages site** under `docs/` (vanilla HTML/CSS/JS, no build) at `ferminrp.github.io/google-sheets-argento/`, with hero, capability cards, step-by-step install (raw `all-in-one.js` links), usage examples, function catalog linking to `doc/*.md`, data sources, FAQ, and footer.
> 
> **README** now links to that URL and replaces the brief install blurb with a numbered Apps Script flow plus a pointer to the site. **`docs/README.md`** documents the `docs/` layout and how to enable Pages from `main` / `/docs`.
> 
> Client-side **`script.js`** adds mobile nav, scroll-based active nav, and copy buttons on code blocks; **`styles.css`** includes light/dark via `prefers-color-scheme`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e51ab590f2a160b2a41a9d816e19fafb61825f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->