### PR TITLE
docs: hero demo con cotizaciones en vivo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog — GitHub Pages (`docs/`)
+
+## [Unreleased]
+
+### Añadido
+- **Hero demo con datos en vivo** (client-side): las 4 celdas de resultado llaman a las mismas APIs públicas que las fórmulas de Sheets, con skeleton mientras cargan.
+  - Blue / MEP → [DolarAPI](https://dolarapi.com/v1/dolares)
+  - GGAL → [data912](https://data912.com/live/arg_stocks)
+  - Riesgo país → [Argentina Datos `/ultimo`](https://api.argentinadatos.com/v1/finanzas/indices/riesgo-pais/ultimo)
+- Badge “Datos en vivo” en la barra del mock cuando al menos una celda carga bien.
+- Mensaje de error solo si fallan las 4 celdas.
+
+### Modificado
+- Se eliminó el disclaimer del hero: *“Los valores de la tabla son ilustrativos…”*.
+- `script.js`: fetch con timeout ~10s, `credentials: 'omit'`, formato `es-AR`.
+- `styles.css`: skeleton shimmer (respeta `prefers-reduced-motion`).
+
+### Archivos afectados
+- `docs/index.html`
+- `docs/script.js`
+- `docs/styles.css`
+- `docs/README.md`
+
+### Decisiones técnicas
+- Client-side puro (CORS abierto en las 3 APIs); sin proxy.
+- Riesgo país usa `/ultimo` en lugar del histórico completo (~400 KB) que consume Apps Script.
+- Un solo request a DolarAPI alimenta blue + mep.
+- Errores por celda (`—`) sin bloquear el resto del sitio.
+
+## [1.0.0] - 2026-07-08
+
+### Añadido
+- Landing estática en GitHub Pages.
+- API estática `api/cedears.json` (generada por `npm run build`).
+- `og.png` alineado a la social preview del repo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,12 +10,25 @@ Esta carpeta es la **landing pública** del proyecto:
 |---------|-----|
 | `index.html` | Landing: qué es, instalación, uso, catálogo, API, fuentes, FAQ |
 | `styles.css` | Estilos (light / dark con `prefers-color-scheme`) |
-| `script.js` | Menú mobile, nav activa, copiar código |
+| `script.js` | Menú mobile, nav activa, copiar código, **demo live del hero** |
 | `favicon.svg` | Icono |
 | `og.png` | Imagen Open Graph / Twitter (misma social preview del repo) |
 | `api/cedears.json` | API estática de CEDEARs + ratios (generada por `npm run build`) |
+| `CHANGELOG.md` | Historial de cambios del sitio |
 
 La documentación detallada de cada función sigue en [`../doc/`](../doc/) del repo (no se duplica acá).
+
+## Demo live del hero
+
+La tabla del hero (`=dolar`, `=acciones`, `=riesgopais`) **no usa valores fijos**: al abrir la página, `script.js` hace 3 `fetch` client-side a las APIs públicas (CORS abierto) y muestra skeleton hasta que llegan los datos.
+
+| Celda | Endpoint |
+|-------|----------|
+| Blue + MEP | `https://dolarapi.com/v1/dolares` |
+| GGAL | `https://data912.com/live/arg_stocks` |
+| Riesgo país | `https://api.argentinadatos.com/v1/finanzas/indices/riesgo-pais/ultimo` |
+
+Si una fuente falla, esa celda muestra `—`. Si fallan las cuatro, aparece un mensaje breve bajo la tabla.
 
 ## API estática
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,12 +63,13 @@
           <a class="btn btn-ghost" href="https://cafecito.app/ferminrp" target="_blank" rel="noopener">Invitame un cafecito</a>
         </div>
 
-        <div class="hero-demo" aria-label="Ejemplo de fórmulas en una hoja">
+        <div class="hero-demo" aria-label="Ejemplo de fórmulas con datos en vivo">
           <div class="hero-demo-bar">
             <span class="dot" aria-hidden="true"></span>
             <span class="dot" aria-hidden="true"></span>
             <span class="dot" aria-hidden="true"></span>
-            Mi planilla · Google Sheets
+            <span class="hero-demo-title">Mi planilla · Google Sheets</span>
+            <span class="hero-demo-live" id="hero-demo-live" hidden>Datos en vivo</span>
           </div>
           <table class="sheet-table">
             <thead>
@@ -82,28 +83,40 @@
               <tr>
                 <td class="cell-label">Dólar blue (venta)</td>
                 <td class="cell-formula">=dolar("blue")</td>
-                <td class="cell-value">1.250,00</td>
+                <td class="cell-value" data-demo="blue" aria-busy="true">
+                  <span class="cell-skeleton" aria-hidden="true"></span>
+                  <span class="cell-value-text sr-only">Cargando…</span>
+                </td>
               </tr>
               <tr>
                 <td class="cell-label">MEP</td>
                 <td class="cell-formula">=dolar("mep";"venta")</td>
-                <td class="cell-value">1.180,50</td>
+                <td class="cell-value" data-demo="mep" aria-busy="true">
+                  <span class="cell-skeleton" aria-hidden="true"></span>
+                  <span class="cell-value-text sr-only">Cargando…</span>
+                </td>
               </tr>
               <tr>
                 <td class="cell-label">Galicia (precio)</td>
                 <td class="cell-formula">=acciones("GGAL";"c")</td>
-                <td class="cell-value">6.420,00</td>
+                <td class="cell-value" data-demo="ggal" aria-busy="true">
+                  <span class="cell-skeleton" aria-hidden="true"></span>
+                  <span class="cell-value-text sr-only">Cargando…</span>
+                </td>
               </tr>
               <tr>
                 <td class="cell-label">Riesgo país</td>
                 <td class="cell-formula">=riesgopais()</td>
-                <td class="cell-value">1.245</td>
+                <td class="cell-value" data-demo="riesgo" aria-busy="true">
+                  <span class="cell-skeleton" aria-hidden="true"></span>
+                  <span class="cell-value-text sr-only">Cargando…</span>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
-        <p class="disclaimer" style="margin-top: 1rem;">
-          Los valores de la tabla son ilustrativos. Las fórmulas traen datos en vivo desde APIs públicas.
+        <p class="hero-demo-error" id="hero-demo-error" hidden>
+          No se pudieron cargar cotizaciones. Probá de nuevo más tarde.
         </p>
       </div>
     </section>

--- a/docs/script.js
+++ b/docs/script.js
@@ -96,4 +96,181 @@
       }
     });
   });
+
+  // ——— Hero demo: cotizaciones en vivo (client-side) ———
+  var FETCH_TIMEOUT_MS = 10000;
+  var URL_DOLAR = 'https://dolarapi.com/v1/dolares';
+  var URL_STOCKS = 'https://data912.com/live/arg_stocks';
+  var URL_RIESGO = 'https://api.argentinadatos.com/v1/finanzas/indices/riesgo-pais/ultimo';
+
+  function formatAR(value, maxFractionDigits) {
+    if (typeof value !== 'number' || !isFinite(value)) return null;
+    return new Intl.NumberFormat('es-AR', {
+      maximumFractionDigits: maxFractionDigits,
+      minimumFractionDigits: 0
+    }).format(value);
+  }
+
+  function cellByDemo(key) {
+    return document.querySelector('.cell-value[data-demo="' + key + '"]');
+  }
+
+  function setCellValue(el, text, isError) {
+    if (!el) return;
+    var skeleton = el.querySelector('.cell-skeleton');
+    var textEl = el.querySelector('.cell-value-text');
+    if (skeleton) skeleton.remove();
+    if (textEl) {
+      textEl.textContent = text;
+      textEl.classList.remove('sr-only');
+    } else {
+      el.textContent = text;
+    }
+    el.setAttribute('aria-busy', 'false');
+    if (isError) {
+      el.classList.add('is-error');
+      el.setAttribute('title', 'No se pudo cargar');
+      el.setAttribute('aria-label', 'No se pudo cargar');
+    } else {
+      el.classList.remove('is-error');
+      el.removeAttribute('title');
+      el.removeAttribute('aria-label');
+    }
+  }
+
+  function setCellError(key) {
+    setCellValue(cellByDemo(key), '—', true);
+  }
+
+  function fetchJson(url) {
+    var controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    var timer = null;
+    if (controller) {
+      timer = setTimeout(function () {
+        controller.abort();
+      }, FETCH_TIMEOUT_MS);
+    }
+
+    return fetch(url, {
+      credentials: 'omit',
+      signal: controller ? controller.signal : undefined
+    }).then(function (res) {
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      return res.json();
+    }).finally(function () {
+      if (timer) clearTimeout(timer);
+    });
+  }
+
+  function findCasa(datos, casa) {
+    if (!datos || !datos.length) return null;
+    for (var i = 0; i < datos.length; i++) {
+      if (datos[i].casa && datos[i].casa.toLowerCase() === casa) {
+        return datos[i];
+      }
+    }
+    return null;
+  }
+
+  function findSymbol(datos, symbol) {
+    if (!datos || !datos.length) return null;
+    var target = symbol.toUpperCase();
+    for (var i = 0; i < datos.length; i++) {
+      if (datos[i].symbol === target) return datos[i];
+    }
+    return null;
+  }
+
+  function loadHeroDemo() {
+    var cells = document.querySelectorAll('.cell-value[data-demo]');
+    if (!cells.length) return;
+
+    var successCount = 0;
+    var settledCount = 0;
+    var totalKeys = 4;
+
+    function markSettled(ok) {
+      settledCount += 1;
+      if (ok) successCount += 1;
+      if (settledCount < totalKeys) return;
+
+      var live = document.getElementById('hero-demo-live');
+      var err = document.getElementById('hero-demo-error');
+      if (successCount > 0 && live) {
+        live.hidden = false;
+      }
+      if (successCount === 0 && err) {
+        err.hidden = false;
+      }
+    }
+
+    // DolarAPI: blue + mep (bolsa) en un solo request
+    fetchJson(URL_DOLAR)
+      .then(function (datos) {
+        var blue = findCasa(datos, 'blue');
+        var bolsa = findCasa(datos, 'bolsa');
+        var blueTxt = blue && blue.venta != null ? formatAR(Number(blue.venta), 2) : null;
+        var mepTxt = bolsa && bolsa.venta != null ? formatAR(Number(bolsa.venta), 2) : null;
+
+        if (blueTxt) {
+          setCellValue(cellByDemo('blue'), blueTxt, false);
+          markSettled(true);
+        } else {
+          setCellError('blue');
+          markSettled(false);
+        }
+
+        if (mepTxt) {
+          setCellValue(cellByDemo('mep'), mepTxt, false);
+          markSettled(true);
+        } else {
+          setCellError('mep');
+          markSettled(false);
+        }
+      })
+      .catch(function () {
+        setCellError('blue');
+        setCellError('mep');
+        markSettled(false);
+        markSettled(false);
+      });
+
+    // data912: GGAL precio (c)
+    fetchJson(URL_STOCKS)
+      .then(function (datos) {
+        var row = findSymbol(datos, 'GGAL');
+        var txt = row && row.c != null ? formatAR(Number(row.c), 2) : null;
+        if (txt) {
+          setCellValue(cellByDemo('ggal'), txt, false);
+          markSettled(true);
+        } else {
+          setCellError('ggal');
+          markSettled(false);
+        }
+      })
+      .catch(function () {
+        setCellError('ggal');
+        markSettled(false);
+      });
+
+    // Argentina Datos: riesgo país último
+    fetchJson(URL_RIESGO)
+      .then(function (datos) {
+        var valor = datos && datos.valor != null ? Number(datos.valor) : NaN;
+        var txt = formatAR(valor, 0);
+        if (txt) {
+          setCellValue(cellByDemo('riesgo'), txt, false);
+          markSettled(true);
+        } else {
+          setCellError('riesgo');
+          markSettled(false);
+        }
+      })
+      .catch(function () {
+        setCellError('riesgo');
+        markSettled(false);
+      });
+  }
+
+  loadHeroDemo();
 })();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -346,6 +346,7 @@ a:hover {
 .hero-demo-bar {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.4rem;
   padding: 0.65rem 1rem;
   background: var(--bg-muted);
@@ -401,6 +402,63 @@ a:hover {
 .sheet-table .cell-value {
   font-variant-numeric: tabular-nums;
   font-weight: 600;
+  min-width: 5.5rem;
+}
+
+.sheet-table .cell-value.is-error {
+  color: var(--ink-muted);
+  font-weight: 500;
+}
+
+.cell-skeleton {
+  display: inline-block;
+  width: 4.5rem;
+  height: 0.95em;
+  border-radius: 4px;
+  vertical-align: middle;
+  background: linear-gradient(
+    90deg,
+    var(--bg-muted) 0%,
+    color-mix(in srgb, var(--bg-elevated) 70%, var(--bg-muted)) 50%,
+    var(--bg-muted) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cell-skeleton {
+    animation: none;
+  }
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+.hero-demo-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.hero-demo-live {
+  margin-left: auto;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--money);
+  background: var(--money-wash);
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.hero-demo-error {
+  margin-top: 1rem;
+  font-size: 0.88rem;
+  color: var(--ink-muted);
 }
 
 .sheet-table .cell-label {


### PR DESCRIPTION
## Summary
- La tabla del hero en GitHub Pages ya no usa valores fijos: trae **datos reales** con `fetch` en el browser.
- Skeleton por celda mientras cargan; badge **Datos en vivo** si al menos una responde; mensaje solo si fallan las 4.
- Se saca el disclaimer *“Los valores de la tabla son ilustrativos…”*.

## Fuentes (mismas que las fórmulas)
| Celda | Endpoint |
|-------|----------|
| Blue + MEP | `dolarapi.com/v1/dolares` |
| GGAL | `data912.com/live/arg_stocks` |
| Riesgo país | `api.argentinadatos.com/.../riesgo-pais/ultimo` |

CORS abierto en las tres → sin proxy. Riesgo usa `/ultimo` (no el histórico de ~400 KB).

## Test plan
- [ ] Abrir preview de Pages o `cd docs && python3 -m http.server 8080`
- [ ] Ver skeletons → números en es-AR en segundos
- [ ] Badge “Datos en vivo” aparece
- [ ] Network: 3 requests 200
- [ ] Offline / bloqueo de red: celdas en `—`; si fallan las 4, mensaje de error
- [ ] Dark mode y mobile OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cambios acotados al sitio estático en `docs/` (UI + fetch client-side); no tocan Apps Script ni lógica de negocio del producto.
> 
> **Overview**
> La tabla del hero en GitHub Pages deja de mostrar números fijos y **carga cotizaciones reales en el navegador** con tres `fetch` a las mismas APIs públicas que usan las fórmulas de Sheets (DolarAPI, data912, Argentina Datos `/ultimo` para riesgo país). Cada celda muestra skeleton hasta responder; si una fuente falla queda `—` sin tumbar el resto; si fallan las cuatro aparece un mensaje bajo la tabla. Cuando al menos una celda carga bien, se muestra el badge **Datos en vivo** en la barra del mock.
> 
> Se quita el disclaimer de valores ilustrativos. `script.js` agrega timeout ~10s, `credentials: 'omit'` y formato `es-AR`; `styles.css` suma shimmer del skeleton (con `prefers-reduced-motion`). `docs/CHANGELOG.md` y `docs/README.md` documentan el comportamiento y los endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a81ec4bc48295127bdb587ba6d43f5f92bdb77ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->