### PR TITLE
Add Market field to CEDEAR list from BYMA

### DIFF
--- a/all-in-one.js
+++ b/all-in-one.js
@@ -452,7 +452,8 @@ function calcularCaucion(
  * @param {string} value El valor que se quiere obtener: 'c' (precio actual), 'v' (volumen),
  *                      'q_bid' (cantidad bid), 'px_bid' (precio bid), 'px_ask' (precio ask),
  *                      'q_ask' (cantidad ask), 'q_op' (operaciones diarias), 'pct_change' (variación porcentual),
- *                      'name' (nombre completo), 'ratio' (ratio de conversión)
+ *                      'name' (nombre completo), 'ratio' (ratio de conversión),
+ *                      'market' (mercado donde cotiza el subyacente)
  * @return El valor del atributo solicitado para el símbolo especificado.
  * @customfunction
  */
@@ -461,13 +462,13 @@ function cedear(symbol, value) {
     throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
   }
   if (value === undefined || value === null || value === '') {
-    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio.");
+    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market.");
   }
 
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
 
-  var atributosPermitidosJson = ['name', 'ratio'];
+  var atributosPermitidosJson = ['name', 'ratio', 'market'];
 
   if (atributosPermitidosJson.includes(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
@@ -486,7 +487,7 @@ function cedear(symbol, value) {
  * Obtiene datos de CEDEARs desde el archivo JSON local.
  *
  * @param {string} symbol El símbolo del CEDEAR
- * @param {string} attribute El atributo que se quiere obtener ('name' o 'ratio')
+ * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio' o 'market')
  * @return El valor del atributo solicitado
  */
 function buscarCedearEnJson(cedears, symbol, attribute) {
@@ -497,6 +498,8 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
       } else if (attribute === 'ratio') {
         // Se devuelve el string original del JSON ("20" o "1:3"). Ver doc/CEDEAR.md.
         return cedears[i].Ratio;
+      } else if (attribute === 'market') {
+        return cedears[i].Market;
       }
     }
   }

--- a/build.js
+++ b/build.js
@@ -143,6 +143,7 @@ function publishCedearsApi() {
         fields: {
             Cedears: 'Ticker del CEDEAR en BYMA',
             Name: 'Nombre de la empresa / instrumento subyacente',
+            Market: 'Mercado donde cotiza el subyacente (ej. NYSE, NASDAQ, B3)',
             Ratio:
                 "String de conversión. Formato 'N' (ej. \"20\") = N CEDEARs por 1 acción; " +
                 "formato 'A:B' (ej. \"1:3\") = razón A:B. No se normaliza.",

--- a/data/cedears.json
+++ b/data/cedears.json
@@ -2,2141 +2,2569 @@
   {
     "Cedears": "AABA",
     "Name": "Altaba Inc.",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "AAL",
     "Name": "American Airlines Group Inc",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "AAP",
     "Name": "Advanced Auto Parts Inc",
+    "Market": "NYSE",
     "Ratio": "14"
   },
   {
     "Cedears": "AAPL",
     "Name": "Apple Inc.",
+    "Market": "NASDAQ",
     "Ratio": "20"
   },
   {
     "Cedears": "ABBV",
     "Name": "AbbVie Inc.",
+    "Market": "NYSE",
     "Ratio": "10"
   },
   {
     "Cedears": "ABEV",
     "Name": "Ambev S.A.",
+    "Market": "NASDAQ",
     "Ratio": "1:3"
   },
   {
     "Cedears": "ABEV3",
     "Name": "Ambev S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "ABNB",
     "Name": "Airbnb Inc",
+    "Market": "NASDAQ GS",
     "Ratio": "15"
   },
   {
     "Cedears": "ABT",
     "Name": "Abbott Labs",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "ACN",
     "Name": "Accenture",
+    "Market": "NYSE",
     "Ratio": "75"
   },
   {
     "Cedears": "ACWI",
     "Name": "iShares MSCI ACWI ETF",
+    "Market": "NASDAQ",
     "Ratio": "26"
   },
   {
     "Cedears": "ADBE",
     "Name": "Adobe Systems Incorporated",
+    "Market": "NASDAQ",
     "Ratio": "44"
   },
   {
     "Cedears": "ADGO",
     "Name": "Adecoagro S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "ADI",
     "Name": "Analog Devices",
+    "Market": "NASDAQ",
     "Ratio": "15"
   },
   {
     "Cedears": "ADP",
     "Name": "Automatic Data Processing Inc.",
+    "Market": "NASDAQ",
     "Ratio": "6"
   },
   {
     "Cedears": "ADS",
     "Name": "Adidas AG",
+    "Market": "XETRA",
     "Ratio": "22"
   },
   {
     "Cedears": "AEG",
     "Name": "Aegon N.V.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "AEM",
     "Name": "Agnico Eagle Mines Limited",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "AI",
     "Name": "C3.AI INC",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "AIG",
     "Name": "American International Group (AIG)",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "AKO.B",
     "Name": "Embotelladora Andina S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "ALAB",
     "Name": "Astera Labs Inc",
+    "Market": "NASDAQ",
     "Ratio": "44"
   },
   {
     "Cedears": "AMAT",
     "Name": "Applied Materials Inc.",
+    "Market": "NASDAQ",
     "Ratio": "5"
   },
   {
     "Cedears": "AMD",
     "Name": "Advanced Micro Devices, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "10"
   },
   {
     "Cedears": "AMGN",
     "Name": "Amgen Inc.",
+    "Market": "NASDAQ",
     "Ratio": "30"
   },
   {
     "Cedears": "AMX",
     "Name": "America Movil",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "AMZN",
     "Name": "Amazon.Com, Inc.",
+    "Market": "NYSE",
     "Ratio": "144"
   },
   {
     "Cedears": "ANET",
     "Name": "Arista Networks Inc",
+    "Market": "NYSE",
     "Ratio": "29"
   },
   {
     "Cedears": "ANF",
     "Name": "Abercrombie & Fitch Co",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "AOCA",
     "Name": "Aluminum Corp Of China",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "ARCO",
     "Name": "Arcos Dorados Holdings Inc.",
+    "Market": "NYSE",
     "Ratio": "1:2"
   },
   {
     "Cedears": "ARKK",
     "Name": "ARK INNOVATION",
+    "Market": "NYSE Arca",
     "Ratio": "10"
   },
   {
     "Cedears": "ARM",
     "Name": "ARM Holdings Plc",
+    "Market": "NASDAQ",
     "Ratio": "27"
   },
   {
     "Cedears": "ASML",
     "Name": "ASML HOLDING NV",
+    "Market": "NASDAQ GS",
     "Ratio": "146"
   },
   {
     "Cedears": "ASR",
     "Name": "Grupo Aeroportuario Del Sureste, S.A.B. de C.V.",
+    "Market": "NYSE",
     "Ratio": "20"
   },
   {
     "Cedears": "ASTS",
     "Name": "AST SpaceMobile Inc",
+    "Market": "NASDAQ",
     "Ratio": "15"
   },
   {
     "Cedears": "ATAD",
     "Name": "Pjsc Tatneft",
+    "Market": "LONDON STOCK EXCHANGE",
     "Ratio": "4"
   },
   {
     "Cedears": "AUY",
     "Name": "Yamana Gold Inc.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "AVGO",
     "Name": "Broadcom Inc.",
+    "Market": "NASDAQ",
     "Ratio": "39"
   },
   {
     "Cedears": "AVY",
     "Name": "Avery Dennison Corp.",
+    "Market": "NYSE",
     "Ratio": "18"
   },
   {
     "Cedears": "AXP",
     "Name": "American Express Co",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "AZN",
     "Name": "Astrazeneca Plc",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "B",
     "Name": "Barrick Gold Corp",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "BA",
     "Name": "The Boeing Company",
+    "Market": "NYSE",
     "Ratio": "24"
   },
   {
     "Cedears": "BABA",
     "Name": "Alibaba Group Holding Limited",
+    "Market": "NYSE",
     "Ratio": "9"
   },
   {
     "Cedears": "BA.C",
     "Name": "Bank Of America Corporation",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "BAK",
     "Name": "Braskem SA",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "BAS",
     "Name": "Basf SE",
+    "Market": "FRANKFURT",
     "Ratio": "2"
   },
   {
     "Cedears": "BAYN",
     "Name": "Bayer AG",
+    "Market": "FRANKFURT",
     "Ratio": "3"
   },
   {
     "Cedears": "BB",
     "Name": "Blackberry Limited",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "BBAS3",
     "Name": "Banco do Brasil S.A.",
+    "Market": "B3",
     "Ratio": "2"
   },
   {
     "Cedears": "BBD",
     "Name": "Banco Bradesco S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "BBDC3",
     "Name": "Banco Bradesco S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "BBV",
     "Name": "Bilbao Vizcaya Argentaria S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "BCS",
     "Name": "Barclays Bank Plc",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "BHP",
     "Name": "Bhp Group Ltd",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "BIDU",
     "Name": "Baidu, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "11"
   },
   {
     "Cedears": "BIIB",
     "Name": "Biogen Inc.",
+    "Market": "NASDAQ",
     "Ratio": "13"
   },
   {
     "Cedears": "BIOX",
     "Name": "Bioceres Crop Solutions Corp.",
+    "Market": "NYSE American",
     "Ratio": "1"
   },
   {
     "Cedears": "BK",
     "Name": "The Bank Of New York Mellon Corp.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "BKNG",
     "Name": "Booking",
+    "Market": "NASDAQ",
     "Ratio": "700"
   },
   {
     "Cedears": "BKR",
     "Name": "Baker Hughes Co",
+    "Market": "NASDAQ",
     "Ratio": "7"
   },
   {
     "Cedears": "BMNR",
     "Name": "Bitmine Inmersion Technologies, Inc.",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "BMY",
     "Name": "Bristol-Myers Squibb Company",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "BNG",
     "Name": "Bunge Limited",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "BP",
     "Name": "BP PCL",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "BPA11",
     "Name": "Banco BTG Pactual S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "BRFS",
     "Name": "BRF S.A.",
+    "Market": "NYSE",
     "Ratio": "1:3"
   },
   {
     "Cedears": "BRKB",
     "Name": "Berkshire Hathaway Inc.",
+    "Market": "NYSE",
     "Ratio": "22"
   },
   {
     "Cedears": "BSBR",
     "Name": "Banco Santander (Brasil) S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "BSN",
     "Name": "Danone",
+    "Market": "FRANKFURT",
     "Ratio": "20"
   },
   {
     "Cedears": "BX",
     "Name": "Blackstone Inc.",
+    "Market": "NYSE",
     "Ratio": "30"
   },
   {
     "Cedears": "C",
     "Name": "Citigroup Inc",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "CAAP",
     "Name": "Corporación America Airports S.A.",
+    "Market": "NYSE",
     "Ratio": "1:4"
   },
   {
     "Cedears": "CAH",
     "Name": "Cardinal Health Inc",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "CAJ",
     "Name": "Canon Inc",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "CAR",
     "Name": "Avis Budget Group Inc.",
+    "Market": "NASDAQ",
     "Ratio": "26"
   },
   {
     "Cedears": "CAT",
     "Name": "Caterpillar Inc",
+    "Market": "NYSE",
     "Ratio": "20"
   },
   {
     "Cedears": "CBRD",
     "Name": "Companhia Brasileira De Dis NPV ADR",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "CCJ",
     "Name": "Cameco Corporation",
+    "Market": "NYSE",
     "Ratio": "23"
   },
   {
     "Cedears": "CCL",
     "Name": "Carnival",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "CDE",
     "Name": "Coeur Mining Inc.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "CEG",
     "Name": "CONSTELLATION ENERGY CORPORATION",
+    "Market": "NASDAQ GS",
     "Ratio": "45"
   },
   {
     "Cedears": "CIBR",
     "Name": "First Trust NASDAQ Cybersecurity",
+    "Market": "NASDAQ GM",
     "Ratio": "10"
   },
   {
     "Cedears": "CL",
     "Name": "Colgate Palmolive Co",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "CLS",
     "Name": "CELESTICA INC",
+    "Market": "NYSE",
     "Ratio": "20"
   },
   {
     "Cedears": "COIN",
     "Name": "Coinbase Global Inc",
+    "Market": "NASDAQ",
     "Ratio": "27"
   },
   {
     "Cedears": "COP",
     "Name": "ConocoPhillips",
+    "Market": "NYSE",
     "Ratio": "25"
   },
   {
     "Cedears": "COPX",
     "Name": "Global X Copper Miners ETF",
+    "Market": "NYSE",
     "Ratio": "14"
   },
   {
     "Cedears": "COST",
     "Name": "Costco Wholesale Corp",
+    "Market": "NASDAQ",
     "Ratio": "48"
   },
   {
     "Cedears": "CRM",
     "Name": "Salesforce Inc.",
+    "Market": "NYSE",
     "Ratio": "18"
   },
   {
     "Cedears": "CRWD",
     "Name": "CrowdStrike Holdings, Inc.",
+    "Market": "NASDAQ GS",
     "Ratio": "79"
   },
   {
     "Cedears": "CRWV",
     "Name": "CoreWeave Inc",
+    "Market": "NASDAQ",
     "Ratio": "27"
   },
   {
     "Cedears": "CS",
     "Name": "Credit Suisse Group",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "CSCO",
     "Name": "Cisco Systems Inc",
+    "Market": "NASDAQ",
     "Ratio": "5"
   },
   {
     "Cedears": "CSNA3",
     "Name": "Companhia Siderúrgica Nacional S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "CVS",
     "Name": "CVS Health",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "CVX",
     "Name": "Chevron Corp.",
+    "Market": "NYSE",
     "Ratio": "16"
   },
   {
     "Cedears": "CX",
     "Name": "Cemex S.A.B. de CV",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "DAL",
     "Name": "Delta Air Lines",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "DD",
     "Name": "Dupont de Nemours Inc.",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "DE",
     "Name": "Deere & Co.",
+    "Market": "NYSE",
     "Ratio": "40"
   },
   {
     "Cedears": "DECK",
     "Name": "DECKERS OUTDOOR CORPORATION",
+    "Market": "NYSE",
     "Ratio": "25"
   },
   {
     "Cedears": "DEO",
     "Name": "Diageo PLC",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "DHR",
     "Name": "Danaher Corp",
+    "Market": "NYSE",
     "Ratio": "54"
   },
   {
     "Cedears": "DIA",
     "Name": "SPDR DOW JONES INDUSTRIAL",
+    "Market": "NYSE Arca",
     "Ratio": "20"
   },
   {
     "Cedears": "DISN",
     "Name": "The Walt Disney Co.",
+    "Market": "NYSE",
     "Ratio": "12"
   },
   {
     "Cedears": "DOCU",
     "Name": "DocuSign Inc.",
+    "Market": "NASDAQ",
     "Ratio": "22"
   },
   {
     "Cedears": "DOW",
     "Name": "DOW Inc",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "DTEA",
     "Name": "Deutsche Telekom Ag",
+    "Market": "OTC US",
     "Ratio": "3"
   },
   {
     "Cedears": "E",
     "Name": "Eni Spa",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "EA",
     "Name": "Electronic Arts Inc",
+    "Market": "NASDAQ",
     "Ratio": "14"
   },
   {
     "Cedears": "EBAY",
     "Name": "Ebay Inc.",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "EBR",
     "Name": "Centrais Eléctricas Brasileiras S.A. - Eletrobras",
+    "Market": "NYSE",
     "Ratio": "1:4"
   },
   {
     "Cedears": "ECL",
     "Name": "Ecolab Inc",
+    "Market": "NYSE",
     "Ratio": "56"
   },
   {
     "Cedears": "EEM",
     "Name": "ISHARES MSCI EMERGING MARKET",
+    "Market": "NYSE Arca",
     "Ratio": "5"
   },
   {
     "Cedears": "EFA",
     "Name": "iShares MSCI EAFE ETF",
+    "Market": "NYSE",
     "Ratio": "18"
   },
   {
     "Cedears": "EFX",
     "Name": "Equifax Inc.",
+    "Market": "NYSE",
     "Ratio": "16"
   },
   {
     "Cedears": "ELP",
     "Name": "Companhia Paranaense de Energía - COPEL",
+    "Market": "NYSE",
     "Ratio": "1:3"
   },
   {
     "Cedears": "EOAN",
     "Name": "E.On Se",
+    "Market": "FRANKFURT",
     "Ratio": "6"
   },
   {
     "Cedears": "EQNR",
     "Name": "Equinor Asa",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "ERIC",
     "Name": "Lm Ericsson Telephone Co.",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "ERJ",
     "Name": "Embraer-Empresa Brasileira de Aeronáutica S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "ESGU",
     "Name": "IShares ESG Aware MSCI USA ETF",
+    "Market": "NASDAQ",
     "Ratio": "30"
   },
   {
     "Cedears": "ETHA",
     "Name": "ISHARES ETHEREUM TR ETF",
+    "Market": "NASDAQ",
     "Ratio": "5"
   },
   {
     "Cedears": "ETSY",
     "Name": "Etsy Inc.",
+    "Market": "NASDAQ",
     "Ratio": "16"
   },
   {
     "Cedears": "EWJ",
     "Name": "iShares MSCI JAPAN ETF",
+    "Market": "NYSE Arca",
     "Ratio": "14"
   },
   {
     "Cedears": "EWY",
     "Name": "iShares MSCI South Korea ETF",
+    "Market": "NYSE ARCA",
     "Ratio": "50"
   },
   {
     "Cedears": "EWZ",
     "Name": "ISHARES MSCI BRAZIL CAP",
+    "Market": "NYSE Arca",
     "Ratio": "2"
   },
   {
     "Cedears": "F",
     "Name": "Ford Motor Company",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "FCX",
     "Name": "Freeport Mcmoran Copper & Gold Inc.",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "FDX",
     "Name": "Fedex Corp",
+    "Market": "NYSE",
     "Ratio": "10"
   },
   {
     "Cedears": "FISV",
     "Name": "Fiserv, Inc.",
+    "Market": "NASDAQ GS",
     "Ratio": "11"
   },
   {
     "Cedears": "FMCC",
     "Name": "Freddie Mac (Federal Home Loan)",
+    "Market": "OTC",
     "Ratio": "1"
   },
   {
     "Cedears": "FMX",
     "Name": "Fomento Economico Mexicano - Femsa",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "FNMA",
     "Name": "Fed. Natl, Mortgage - Fannie Mae",
+    "Market": "OTC",
     "Ratio": "1"
   },
   {
     "Cedears": "FSLR",
     "Name": "First Solar Inc.",
+    "Market": "NASDAQ",
     "Ratio": "18"
   },
   {
     "Cedears": "FXI",
     "Name": "ISHARES CHINA LARGE-CAP ETF",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "GDX",
     "Name": "Van Eck Gold Miners ETF/USA",
+    "Market": "NYSE",
     "Ratio": "10"
   },
   {
     "Cedears": "GE",
     "Name": "General Electric Co.",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "GFI",
     "Name": "Gold Fields Ltd.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "GGB",
     "Name": "Gerdau S.A.",
+    "Market": "NYSE",
     "Ratio": "1:4"
   },
   {
     "Cedears": "GILD",
     "Name": "Gilead Sciences, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "4"
   },
   {
     "Cedears": "GLD",
     "Name": "ETF SPDR GOLD TRUST",
+    "Market": "NYSE",
     "Ratio": "50"
   },
   {
     "Cedears": "GLNG",
     "Name": "Golar LNG Ltd.",
+    "Market": "NASDAQ GS",
     "Ratio": "10"
   },
   {
     "Cedears": "GLOB",
     "Name": "Globant S.A.",
+    "Market": "NYSE",
     "Ratio": "18"
   },
   {
     "Cedears": "GLW",
     "Name": "Corning Inc.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "GM",
     "Name": "General Motors Co",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "GOOGL",
     "Name": "Alphabet Inc.",
+    "Market": "NASDAQ",
     "Ratio": "58"
   },
   {
     "Cedears": "GPRK",
     "Name": "Geopark Ltd.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "GRMN",
     "Name": "Garmin Ltd.",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "GS",
     "Name": "The Goldman Sachs Group, Inc",
+    "Market": "NYSE",
     "Ratio": "13"
   },
   {
     "Cedears": "GSK",
     "Name": "GSK Plc.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "GT",
     "Name": "Goodyear Tire & Rubber co./the",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "HAL",
     "Name": "Halliburton Co.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "HAPV3",
     "Name": "Hapvida Participacoes E Investimentos S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "HD",
     "Name": "The Home Depot Inc.",
+    "Market": "NYSE",
     "Ratio": "32"
   },
   {
     "Cedears": "HDB",
     "Name": "Hdfc Bank Limited.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "HHPD",
     "Name": "Hon Hai Precision Industry Co. Ltd.",
+    "Market": "LONDON STOCK EXCHANGE",
     "Ratio": "2"
   },
   {
     "Cedears": "HIMS",
     "Name": "Hims & Hers Health, Inc.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "HL",
     "Name": "Hecla Mining Co.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "HMC",
     "Name": "Honda Motor Co. Ltd",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "HMY",
     "Name": "Harmony Gold Mining Company Ltd.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "HNPIY",
     "Name": "Huaneng Power Intl",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "HOG",
     "Name": "Harley-Davidson Inc.",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "HON",
     "Name": "Honeywell International Inc.",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "HOOD",
     "Name": "Robinhood Markets Inc",
+    "Market": "NASDAQ",
     "Ratio": "29"
   },
   {
     "Cedears": "HPQ",
     "Name": "Hp Inc",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "HSBC",
     "Name": "Hsbc Holdings Plc",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "HSY",
     "Name": "The Hershey Company",
+    "Market": "NYSE",
     "Ratio": "21"
   },
   {
     "Cedears": "HUT",
     "Name": "Hut 8 Mining Corp.",
+    "Market": "NASDAQ GS",
     "Ratio": "5"
   },
   {
     "Cedears": "HWM",
     "Name": "Howmet Aerospace Inc.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "IBB",
     "Name": "iShares Nasdaq Biotechnology ETF",
+    "Market": "NASDAQ",
     "Ratio": "27"
   },
   {
     "Cedears": "IBIT",
     "Name": "ISHARES BITCOIN TRUST",
+    "Market": "NASDAQ",
     "Ratio": "10"
   },
   {
     "Cedears": "IBM",
     "Name": "International Business Machines",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "IBN",
     "Name": "Icici Bank Ltd.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "ICLN",
     "Name": "iShares Global Clean Energy ETF",
+    "Market": "NASDAQ GM",
     "Ratio": "5"
   },
   {
     "Cedears": "IEMG",
     "Name": "iShares Core MSCI Emerging Markets ETF",
+    "Market": "NYSE",
     "Ratio": "12"
   },
   {
     "Cedears": "IEUR",
     "Name": "iShares Core MSCI Europe ETF",
+    "Market": "NYSE Arca",
     "Ratio": "11"
   },
   {
     "Cedears": "IFF",
     "Name": "International Flavors & Fragrances Inc.",
+    "Market": "NYSE",
     "Ratio": "12"
   },
   {
     "Cedears": "IJH",
     "Name": "iShares CORE S&P MID-CAP ETF",
+    "Market": "NYSE Arca",
     "Ratio": "12"
   },
   {
     "Cedears": "ILF",
     "Name": "IShares Latin America 40 ETF",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "INFY",
     "Name": "Infosys Limited",
+    "Market": "NASDAQ",
     "Ratio": "1"
   },
   {
     "Cedears": "ING",
     "Name": "Ing Groep Nv",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "INTC",
     "Name": "Intel Corporation",
+    "Market": "NASDAQ",
     "Ratio": "5"
   },
   {
     "Cedears": "IP",
     "Name": "International Paper Co.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "IREN",
     "Name": "Iren Ltd",
+    "Market": "NASDAQ",
     "Ratio": "12"
   },
   {
     "Cedears": "ISRG",
     "Name": "Intuitive Surgical inc",
+    "Market": "NASDAQ",
     "Ratio": "90"
   },
   {
     "Cedears": "ITA",
     "Name": "iShares U.S. Aerospace & Defense",
+    "Market": "CBOE",
     "Ratio": "50"
   },
   {
     "Cedears": "ITUB",
     "Name": "Itaú Unibanco Holding S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "ITUB3",
     "Name": "Banco Itaú Unibanco S.A",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "IVE",
     "Name": "iShares S&P 500 Value ETF",
+    "Market": "NYSE Arca",
     "Ratio": "40"
   },
   {
     "Cedears": "IVV",
     "Name": "IShares Core S&P 500 ETF",
+    "Market": "NYSE",
     "Ratio": "692"
   },
   {
     "Cedears": "IVW",
     "Name": "iShares S&P 500 Growth ETF",
+    "Market": "NYSE Arca",
     "Ratio": "20"
   },
   {
     "Cedears": "IWM",
     "Name": "ISHARES TRUST RUSSELL 2000",
+    "Market": "NYSE Arca",
     "Ratio": "10"
   },
   {
     "Cedears": "JCI",
     "Name": "Johnson Controls International",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "JD",
     "Name": "Jd.Com, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "4"
   },
   {
     "Cedears": "JMIA",
     "Name": "Adr Jumia Technologies Ag",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "JNJ",
     "Name": "Johnson & Johnson",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "JOYY",
     "Name": "JOYY Inc.",
+    "Market": "NASDAQ",
     "Ratio": "5"
   },
   {
     "Cedears": "JPM",
     "Name": "J.P. Morgan & Chase Co.",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "KB",
     "Name": "Kb Financial Group Inc.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "KEEL",
     "Name": "Bitfarms Ltd.",
+    "Market": "NASDAQ GM",
     "Ratio": "1:5"
   },
   {
     "Cedears": "KEP",
     "Name": "Korea Electric Power Corp.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "KGC",
     "Name": "Kinross Gold Corp",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "KMB",
     "Name": "Kimberly-Clark Corp.",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "KO",
     "Name": "The Coca Cola Company",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "KOFM",
     "Name": "Coca-Cola Femsa, S.A.B. De C.V.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "LAC",
     "Name": "Lithium Americas Corp",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "LAR",
     "Name": "Lithium Americas (Argentina) Corp",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "LFC",
     "Name": "China Life Insurance",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "LKOD",
     "Name": "Pjsc Lukoil",
+    "Market": "LONDON STOCK EXCHANGE",
     "Ratio": "4"
   },
   {
     "Cedears": "LLY",
     "Name": "Eli Lilly and Company",
+    "Market": "NYSE",
     "Ratio": "56"
   },
   {
     "Cedears": "LMT",
     "Name": "Lockheed Martin Corporation",
+    "Market": "NYSE",
     "Ratio": "20"
   },
   {
     "Cedears": "LND",
     "Name": "Brasilagro - Co Brasileira de Propriedades Agrícolas",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "LRCX",
     "Name": "Lam Research Corp",
+    "Market": "NASDAQ",
     "Ratio": "56"
   },
   {
     "Cedears": "LREN3",
     "Name": "Lojas Renner S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "LVS",
     "Name": "Las Vegas Sands Corp",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "LYG",
     "Name": "Lloyds Banking Group Plc",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "MA",
     "Name": "Mastercard Inc.",
+    "Market": "NYSE",
     "Ratio": "33"
   },
   {
     "Cedears": "MBG",
     "Name": "Mercedes-Benz Group AG",
+    "Market": "FRANKFURT",
     "Ratio": "4"
   },
   {
     "Cedears": "MBT",
     "Name": "Mobile Telesystems",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "MCD",
     "Name": "Mcdonald'S Corp.",
+    "Market": "NYSE",
     "Ratio": "24"
   },
   {
     "Cedears": "MDLZ",
     "Name": "Mondelez",
+    "Market": "NASDAQ",
     "Ratio": "15"
   },
   {
     "Cedears": "MDT",
     "Name": "Medtronic Public Limited Company",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "MELI",
     "Name": "Mercadolibre Inc.",
+    "Market": "NASDAQ",
     "Ratio": "120"
   },
   {
     "Cedears": "META",
     "Name": "Meta Platforms Inc",
+    "Market": "NASDAQ",
     "Ratio": "24"
   },
   {
     "Cedears": "MFG",
     "Name": "Mizuho Financial Group",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "MGLU3",
     "Name": "Magazine Luiza S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "MMC",
     "Name": "Marsh & Mclennan Companies Inc.",
+    "Market": "NYSE",
     "Ratio": "16"
   },
   {
     "Cedears": "MMM",
     "Name": "3M Company",
+    "Market": "NYSE",
     "Ratio": "10"
   },
   {
     "Cedears": "MO",
     "Name": "Altria Group Inc.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "MOS",
     "Name": "The Mosaic Co",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "MP",
     "Name": "MP Materials Corp.",
+    "Market": "NYSE",
     "Ratio": "10"
   },
   {
     "Cedears": "MRK",
     "Name": "Merck & Co. Inc.",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "MRNA",
     "Name": "Moderna Inc",
+    "Market": "NASDAQ",
     "Ratio": "19"
   },
   {
     "Cedears": "MRVL",
     "Name": "Marvell Technology Inc",
+    "Market": "NASDAQ",
     "Ratio": "14"
   },
   {
     "Cedears": "MSFT",
     "Name": "Microsoft Corp.",
+    "Market": "NASDAQ",
     "Ratio": "30"
   },
   {
     "Cedears": "MSI",
     "Name": "Motorola Solutions, Inc.",
+    "Market": "NYSE",
     "Ratio": "20"
   },
   {
     "Cedears": "MSTR",
     "Name": "Microstrategy Inc Cl A New",
+    "Market": "NASDAQ GS",
     "Ratio": "20"
   },
   {
     "Cedears": "MU",
     "Name": "Micron Technology Inc",
+    "Market": "NASDAQ GS",
     "Ratio": "5"
   },
   {
     "Cedears": "MUFG",
     "Name": "Mitsubishi Ufj Financial Group",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "MUX",
     "Name": "McEwen Mining Inc",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "NATU3",
     "Name": "Natura Cosméticos S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "NBIS",
     "Name": "Nebius Group N.V.",
+    "Market": "NASDAQ GS",
     "Ratio": "27"
   },
   {
     "Cedears": "NEC1",
     "Name": "Nec Corporation",
+    "Market": "FRANKFURT",
     "Ratio": "1:3"
   },
   {
     "Cedears": "NEE",
     "Name": "NextEra Energy, Inc.",
+    "Market": "NYSE",
     "Ratio": "19"
   },
   {
     "Cedears": "NEM",
     "Name": "Newmont Corporation",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "NFLX",
     "Name": "Netflix, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "48"
   },
   {
     "Cedears": "NG",
     "Name": "Novagold Resources INC.",
+    "Market": "NYSE",
     "Ratio": "1:4"
   },
   {
     "Cedears": "NGG",
     "Name": "National Grid Plc",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "NIO",
     "Name": "NIO Inc.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "NKE",
     "Name": "Nike Inc.",
+    "Market": "NYSE",
     "Ratio": "12"
   },
   {
     "Cedears": "NLM",
     "Name": "Novolipetsk Steel PJSC",
+    "Market": "LONDON STOCK EXCHANGE",
     "Ratio": "2"
   },
   {
     "Cedears": "NMR",
     "Name": "Nomura Holdings, Inc",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "NOKA",
     "Name": "Nokia Corporation",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "NOW",
     "Name": "SERVICENOW INC",
+    "Market": "NYSE",
     "Ratio": "172"
   },
   {
     "Cedears": "NSAN",
     "Name": "Nissan Motor Co., Ltd",
+    "Market": "OTC US",
     "Ratio": "1"
   },
   {
     "Cedears": "NTES",
     "Name": "Netease, Inc",
+    "Market": "NASDAQ",
     "Ratio": "14"
   },
   {
     "Cedears": "NUE",
     "Name": "Nucor Corp",
+    "Market": "NYSE",
     "Ratio": "16"
   },
   {
     "Cedears": "NVDA",
     "Name": "Nvidia Corporation",
+    "Market": "NASDAQ",
     "Ratio": "24"
   },
   {
     "Cedears": "NVO",
     "Name": "Novo Nordisk A/S",
+    "Market": "NYSE",
     "Ratio": "7"
   },
   {
     "Cedears": "NVS",
     "Name": "Novartis Ag",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "NXE",
     "Name": "Nexgen Energy LTD",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "O",
     "Name": "Realty Income Corp.",
+    "Market": "NYSE",
     "Ratio": "13"
   },
   {
     "Cedears": "OGZD",
     "Name": "Pjsc Gazprom",
+    "Market": "LONDON STOCK EXCHANGE",
     "Ratio": "2"
   },
   {
     "Cedears": "OKLO",
     "Name": "Oklo Inc",
+    "Market": "NYSE",
     "Ratio": "28"
   },
   {
     "Cedears": "ONDS",
     "Name": "Ondas Holdings Inc.",
+    "Market": "NASDAQ CM",
     "Ratio": "2"
   },
   {
     "Cedears": "ORAN",
     "Name": "Orange S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "ORCL",
     "Name": "Oracle Corporation",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "ORLY",
     "Name": "O'reilly Automotive Inc",
+    "Market": "NASDAQ",
     "Ratio": "222"
   },
   {
     "Cedears": "OXY",
     "Name": "Occidental Petroleum Corp.",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "PAAS",
     "Name": "Pan American Silver Corp.",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "PAC",
     "Name": "Grupo Aeroportuario del Pacifico, S.A.B. de C.V.",
+    "Market": "NYSE",
     "Ratio": "16"
   },
   {
     "Cedears": "PAGS",
     "Name": "Pagseguro Digital Ltd",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "PANW",
     "Name": "Palo Alto Networks Inc",
+    "Market": "NASDAQ GS",
     "Ratio": "50"
   },
   {
     "Cedears": "PATH",
     "Name": "UIPATH INC",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "PBI",
     "Name": "Pitney Bowes Inc",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "PBR",
     "Name": "Petrobras (ADR)",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "PCAR",
     "Name": "Paccar Inc.",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "PCRF",
     "Name": "Panasonic Corporation",
+    "Market": "OTC US",
     "Ratio": "2"
   },
   {
     "Cedears": "PDD",
     "Name": "PDD HOLDINGS INC",
+    "Market": "NASDAQ GS",
     "Ratio": "25"
   },
   {
     "Cedears": "PEP",
     "Name": "Pepsico Inc",
+    "Market": "NASDAQ",
     "Ratio": "18"
   },
   {
     "Cedears": "PETR3",
     "Name": "Petrobras - Petróleo Brasileiro S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "PFE",
     "Name": "Pfizer Inc.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "PG",
     "Name": "Procter & Gamble",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "PHG",
     "Name": "Koninklijke Philips N.V.",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "PINS",
     "Name": "Pinterest",
+    "Market": "NYSE",
     "Ratio": "7"
   },
   {
     "Cedears": "PKS",
     "Name": "Posco Holdings Inc.",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "PLTR",
     "Name": "Palantir Technologies Inc",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "PM",
     "Name": "Philip Morris International",
+    "Market": "NYSE",
     "Ratio": "18"
   },
   {
     "Cedears": "PRIO3",
     "Name": "Petro Rio S.A.",
+    "Market": "B3",
     "Ratio": "2"
   },
   {
     "Cedears": "PSO",
     "Name": "Pearson Plc",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "PSQ",
     "Name": "PROSHARES SHORT QQQ",
+    "Market": "NYSE Arca",
     "Ratio": "8"
   },
   {
     "Cedears": "PSX",
     "Name": "Phillips 66",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "PTR",
     "Name": "Petrochina Co Ltd",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "PYPL",
     "Name": "Paypal Holdings, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "8"
   },
   {
     "Cedears": "QCOM",
     "Name": "Qualcomm Inc.",
+    "Market": "NASDAQ",
     "Ratio": "11"
   },
   {
     "Cedears": "QQQ",
     "Name": "INVESCO QQQ TRUST",
+    "Market": "NASDAQ",
     "Ratio": "20"
   },
   {
     "Cedears": "RACE",
     "Name": "Ferrari",
+    "Market": "NYSE",
     "Ratio": "83"
   },
   {
     "Cedears": "RBLX",
     "Name": "Roblox Corp.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "RCTB4",
     "Name": "Telebras PN",
+    "Market": "BOVESPA",
     "Ratio": "1:1000"
   },
   {
     "Cedears": "RGTI",
     "Name": "RIGETTI COMPUTING INC",
+    "Market": "NASDAQ CM",
     "Ratio": "2"
   },
   {
     "Cedears": "RENT3",
     "Name": "Localiza Rent A Car S.A.",
+    "Market": "B3",
     "Ratio": "2"
   },
   {
     "Cedears": "RIO",
     "Name": "Rio Tinto Plc",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "RIOT",
     "Name": "Riot Platforms",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "RKLB",
     "Name": "Rocket Lab Corp",
+    "Market": "NASDAQ",
     "Ratio": "12"
   },
   {
     "Cedears": "ROKU",
     "Name": "Roku",
+    "Market": "NASDAQ",
     "Ratio": "13"
   },
   {
     "Cedears": "ROST",
     "Name": "Ross Stores, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "4"
   },
   {
     "Cedears": "RSP",
     "Name": "Invesco S&P 500 Equal Weight ETF",
+    "Market": "NYSE ARCA",
     "Ratio": "30"
   },
   {
     "Cedears": "RTX",
     "Name": "Raytheon Technologies Corp",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "SAN",
     "Name": "Banco Santander S.A",
+    "Market": "NYSE",
     "Ratio": "1:4"
   },
   {
     "Cedears": "SAP",
     "Name": "Sap Se",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "SATL",
     "Name": "Satellogic Inc.",
+    "Market": "NASDAQ GS",
     "Ratio": "1"
   },
   {
     "Cedears": "SBS",
     "Name": "Companhia de Saneamento Básico do Estado de São Paulo–Sabesp",
+    "Market": "NYSE",
     "Ratio": "1:2"
   },
   {
     "Cedears": "SBSP3",
     "Name": "Cia Saneamento Básico de SP",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "SBUX",
     "Name": "Starbucks Corporation",
+    "Market": "NASDAQ",
     "Ratio": "12"
   },
   {
     "Cedears": "SCCO",
     "Name": "Southern Copper Corp",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "SCHW",
     "Name": "Charles Schwab",
+    "Market": "NYSE",
     "Ratio": "13"
   },
   {
     "Cedears": "SDA",
     "Name": "SunCar Technology Group Inc",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "SE",
     "Name": "Sea Ltd.",
+    "Market": "NYSE",
     "Ratio": "32"
   },
   {
     "Cedears": "SH",
     "Name": "PROSHARES SHORT S&P500",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "SHEL",
     "Name": "Royal Dutch Shell Plc",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "SHOP",
     "Name": "Shopify Inc.",
+    "Market": "NYSE",
     "Ratio": "107"
   },
   {
     "Cedears": "SHPW",
     "Name": "Shapeways Holdings Inc",
+    "Market": "NYSE",
     "Ratio": "1:2"
   },
   {
     "Cedears": "SI",
     "Name": "Silvergate Bancorp",
+    "Market": "NYSE",
     "Ratio": "10"
   },
   {
     "Cedears": "SID",
     "Name": "Companhia Siderúrgica Nacional",
+    "Market": "NYSE",
     "Ratio": "1:8"
   },
   {
     "Cedears": "SIEGY",
     "Name": "Siemens Ag Adr",
+    "Market": "OTC",
     "Ratio": "3"
   },
   {
     "Cedears": "SLB",
     "Name": "Schlumberger Ltd",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "SLV",
     "Name": "iShares SILVER TRUST",
+    "Market": "NYSE Arca",
     "Ratio": "6"
   },
   {
     "Cedears": "SMH",
     "Name": "VAN ECK SEMICONDUCTOR ETF",
+    "Market": "NASDAQ",
     "Ratio": "50"
   },
   {
     "Cedears": "SMSN",
     "Name": "Samsung Electronics Co. Ltd.",
+    "Market": "LONDON STOCK EXCHANGE",
     "Ratio": "14"
   },
   {
     "Cedears": "SNA",
     "Name": "Snap-On Inc",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "SNAP",
     "Name": "Snap Inc.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "SNDK",
     "Name": "Sandisk Corporation",
+    "Market": "NASDAQ GS",
     "Ratio": "170"
   },
   {
     "Cedears": "SNOW",
     "Name": "Snowflake Inc.",
+    "Market": "NYSE",
     "Ratio": "30"
   },
   {
     "Cedears": "SNP",
     "Name": "China Petroleum & Chem",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "SONY",
     "Name": "Sony Group Corporation",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "SPCE",
     "Name": "Virgin Galactic",
+    "Market": "NYSE",
     "Ratio": "1:2"
   },
   {
     "Cedears": "SPCX",
     "Name": "Space Exploration Technologies Corp.",
+    "Market": "NASDAQ GS",
     "Ratio": "50"
   },
   {
     "Cedears": "SPGI",
     "Name": "S&P Global Inc",
+    "Market": "NYSE",
     "Ratio": "45"
   },
   {
     "Cedears": "SPHQ",
     "Name": "Invesco S&P 500 Quality ETF",
+    "Market": "NYSE ARCA",
     "Ratio": "14"
   },
   {
     "Cedears": "SPOT",
     "Name": "Spotify Technology S.A.",
+    "Market": "NYSE",
     "Ratio": "28"
   },
   {
     "Cedears": "SPXL",
     "Name": "DIREXION DAILY S&P 500 BULL 3X",
+    "Market": "NYSE Arca",
     "Ratio": "25"
   },
   {
     "Cedears": "SPY",
     "Name": "SPDR S&P 500",
+    "Market": "NYSE Arca",
     "Ratio": "60"
   },
   {
     "Cedears": "STLA",
     "Name": "Stellantis",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "STNE",
     "Name": "StoneCo Ltd",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "SUZ",
     "Name": "Suzano Papel E Celulose S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "SUZB3",
     "Name": "Suzano S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "SWKS",
     "Name": "Skyworks Solutions",
+    "Market": "NASDAQ",
     "Ratio": "21"
   },
   {
     "Cedears": "SYY",
     "Name": "Sysco Corp.",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "T",
     "Name": "At &T Inc.",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "TCOM",
     "Name": "TRIP.COM Group Ltd.",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "TEAM",
     "Name": "ATLASSIAN CORPORATION",
+    "Market": "NASDAQ GS",
     "Ratio": "47"
   },
   {
     "Cedears": "TEFO",
     "Name": "Telefonica S.A.",
+    "Market": "NYSE",
     "Ratio": "8"
   },
   {
     "Cedears": "TEM",
     "Name": "TEMPUS AI INC",
+    "Market": "NASDAQ GS",
     "Ratio": "12"
   },
   {
     "Cedears": "TEN",
     "Name": "Tenaris",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "TGT",
     "Name": "Target Corporation",
+    "Market": "NYSE",
     "Ratio": "24"
   },
   {
     "Cedears": "TIIAY",
     "Name": "Telecom Italia S.P.A. Ordinary Shares",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "TIMB",
     "Name": "Tim Participações S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "TIMS3",
     "Name": "TIM S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "TJX",
     "Name": "TJX Companies Inc/The",
+    "Market": "NYSE",
     "Ratio": "22"
   },
   {
     "Cedears": "TM",
     "Name": "Toyota Motor Corporation",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "TMO",
     "Name": "Thermo Fisher Scientific Inc.",
+    "Market": "NYSE",
     "Ratio": "22"
   },
   {
     "Cedears": "TMUS",
     "Name": "T-mobile",
+    "Market": "NASDAQ",
     "Ratio": "33"
   },
   {
     "Cedears": "TQQQ",
     "Name": "ProShares UltraPro QQQ",
+    "Market": "NASDAQ",
     "Ratio": "25"
   },
   {
     "Cedears": "TRIP",
     "Name": "Tripadvisor, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "TRVV",
     "Name": "The Travelers Cos. Inc.",
+    "Market": "NYSE",
     "Ratio": "6"
   },
   {
     "Cedears": "TSLA",
     "Name": "Tesla, Inc.",
+    "Market": "NASDAQ",
     "Ratio": "15"
   },
   {
     "Cedears": "TSM",
     "Name": "Taiwan Semiconductor Manufacturing",
+    "Market": "NYSE",
     "Ratio": "9"
   },
   {
     "Cedears": "TTE",
     "Name": "TotalEnergies SE",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "TTM",
     "Name": "Tata Motors Ltd",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "TV",
     "Name": "Grupo Televisa S.A.",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "TWLO",
     "Name": "Twilio Inc",
+    "Market": "NYSE",
     "Ratio": "36"
   },
   {
     "Cedears": "TWTR",
     "Name": "Twitter, Inc.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "TXN",
     "Name": "Texas Instruments Inc",
+    "Market": "NASDAQ",
     "Ratio": "5"
   },
   {
     "Cedears": "TXR",
     "Name": "Ternium S.A.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "UAL",
     "Name": "United Airlines Holdings Inc.",
+    "Market": "NASDAQ GS",
     "Ratio": "5"
   },
   {
     "Cedears": "UBER",
     "Name": "Uber Technologies Inc.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "UGP",
     "Name": "Ultrapar Participações S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "UL",
     "Name": "Unilever PLC - Sponsored",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "UN",
     "Name": "NU Holdings Ltd/Cayman Islands",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "UNH",
     "Name": "UnitedHealth Group Inc.",
+    "Market": "NYSE",
     "Ratio": "33"
   },
   {
     "Cedears": "UNP",
     "Name": "Union Pacific Corp.",
+    "Market": "NYSE",
     "Ratio": "20"
   },
   {
     "Cedears": "UPST",
     "Name": "Upstart Hldgs Inc",
+    "Market": "NASDAQ GS",
     "Ratio": "5"
   },
   {
     "Cedears": "URA",
     "Name": "Global X Uranium ETF",
+    "Market": "NYSE Arca",
     "Ratio": "5"
   },
   {
     "Cedears": "URBN",
     "Name": "Urban Outfitters INC.",
+    "Market": "NASDAQ",
     "Ratio": "2"
   },
   {
     "Cedears": "USB",
     "Name": "U.S. Bancorp",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "USO",
     "Name": "United States Oil Fund",
+    "Market": "NYSE",
     "Ratio": "15"
   },
   {
     "Cedears": "V",
     "Name": "Visa Inc",
+    "Market": "NYSE",
     "Ratio": "18"
   },
   {
     "Cedears": "VALE",
     "Name": "Vale S.A.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "VALE3",
     "Name": "Vale S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "VEA",
     "Name": "Vanguard FTSE Developed Markets ETF",
+    "Market": "NYSE Arca",
     "Ratio": "10"
   },
   {
     "Cedears": "VIG",
     "Name": "VANGUARD DIVIDEND APPRECIATION",
+    "Market": "NYSE Arca",
     "Ratio": "39"
   },
   {
     "Cedears": "VIST",
     "Name": "Vista Energy S.A.B. de C.V.",
+    "Market": "NYSE",
     "Ratio": "3"
   },
   {
     "Cedears": "VIV",
     "Name": "Telefônica Brasil S.A.",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "VIVT3",
     "Name": "Telefônica Brasil S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "VOD",
     "Name": "Vodafone Group Plc",
+    "Market": "NASDAQ",
     "Ratio": "1"
   },
   {
     "Cedears": "VRSN",
     "Name": "Verisign, Inc.",
+    "Market": "-",
     "Ratio": "6"
   },
   {
     "Cedears": "VRTX",
     "Name": "VERTEX PHARMACEUTICALS INC",
+    "Market": "NYSE",
     "Ratio": "101"
   },
   {
     "Cedears": "VST",
     "Name": "VISTRA CORPORATION",
+    "Market": "NYSE",
     "Ratio": "26"
   },
   {
     "Cedears": "VXX",
     "Name": "iPath Series B S&P 500 VIX",
+    "Market": "CBOE",
     "Ratio": "5"
   },
   {
     "Cedears": "VZ",
     "Name": "Verizon Communications Inc.",
+    "Market": "NYSE",
     "Ratio": "4"
   },
   {
     "Cedears": "WBA",
     "Name": "Walgreens Boots Alliance Inc.",
+    "Market": "NASDAQ",
     "Ratio": "3"
   },
   {
     "Cedears": "WBO",
     "Name": "Weibo Corporation",
+    "Market": "NASDAQ",
     "Ratio": "6"
   },
   {
     "Cedears": "WEGE3",
     "Name": "Weg S.A.",
+    "Market": "B3",
     "Ratio": "1"
   },
   {
     "Cedears": "WFC",
     "Name": "Wells Fargo & Co.",
+    "Market": "NYSE",
     "Ratio": "5"
   },
   {
     "Cedears": "WMT",
     "Name": "Walmart Inc.",
+    "Market": "NYSE",
     "Ratio": "18"
   },
   {
     "Cedears": "XLB",
     "Name": "The Materials Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "18"
   },
   {
     "Cedears": "XLC",
     "Name": "The Communication Services Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "19"
   },
   {
     "Cedears": "XLE",
     "Name": "ENERGY SELECT SECTOR SPDR FUND",
+    "Market": "NYSE Arca",
     "Ratio": "2"
   },
   {
     "Cedears": "XLF",
     "Name": "FINANCIAL SELECT SECTOR SPDR FUND",
+    "Market": "NYSE Arca",
     "Ratio": "2"
   },
   {
     "Cedears": "XLI",
     "Name": "The Industrial Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "28"
   },
   {
     "Cedears": "XLK",
     "Name": "The Technology Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "46"
   },
   {
     "Cedears": "XLP",
     "Name": "The Consumer Staples Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "16"
   },
   {
     "Cedears": "XLRE",
     "Name": "The Real Estate Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "9"
   },
   {
     "Cedears": "XLU",
     "Name": "Utilities Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "15"
   },
   {
     "Cedears": "XLV",
     "Name": "The Health Care Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "29"
   },
   {
     "Cedears": "XME",
     "Name": "State Street SPDR S&P Metals & Mining ETF",
+    "Market": "NYSE ARCA",
     "Ratio": "30"
   },
   {
     "Cedears": "XLY",
     "Name": "The Consumer Discretionary Select Sector SPDR Fund",
+    "Market": "NYSE Arca",
     "Ratio": "43"
   },
   {
     "Cedears": "XOM",
     "Name": "Exxon Mobil Corporation",
+    "Market": "NYSE",
     "Ratio": "10"
   },
   {
     "Cedears": "XP",
     "Name": "XP Inc",
+    "Market": "NASDAQ",
     "Ratio": "4"
   },
   {
     "Cedears": "XPEV",
     "Name": "XPENG INC",
+    "Market": "New York",
     "Ratio": "4"
   },
   {
     "Cedears": "XROX",
     "Name": "Xerox Holding Corporation",
+    "Market": "NYSE",
     "Ratio": "1"
   },
   {
     "Cedears": "XYZ",
     "Name": "Square Inc.",
+    "Market": "NYSE",
     "Ratio": "20"
   },
   {
     "Cedears": "YELP",
     "Name": "Yelp Inc.",
+    "Market": "NYSE",
     "Ratio": "2"
   },
   {
     "Cedears": "YZCA",
     "Name": "Yanzhou Coal Mining Co. Ltd.",
+    "Market": "OTC US",
     "Ratio": "2"
   },
   {
     "Cedears": "ZM",
     "Name": "Zoom Video Communications Inc.",
+    "Market": "NASDAQ",
     "Ratio": "47"
   }
 ]

--- a/data/cedears_byma.md
+++ b/data/cedears_byma.md
@@ -1,0 +1,431 @@
+| Nombre de la Compañía | Código BYMA | Mercado donde Cotiza | Ratio (*) |
+|---|---:|---|---:|
+| Altaba Inc. | AABA | NASDAQ | 3:1 |
+| American Airlines Group Inc | AAL | NASDAQ | 2:1 |
+| Advanced Auto Parts Inc | AAP | NYSE | 14:1 |
+| Apple Inc. | AAPL | NASDAQ | 20:1 |
+| AbbVie Inc. | ABBV | NYSE | 10:1 |
+| Ambev S.A. | ABEV | NASDAQ | 1:3 |
+| Ambev S.A. | ABEV3 | B3 | 1:1 |
+| Airbnb Inc | ABNB | NASDAQ GS | 15:1 |
+| Abbott Labs | ABT | NYSE | 4:1 |
+| Accenture | ACN | NYSE | 75:1 |
+| iShares MSCI ACWI ETF | ACWI | NASDAQ | 26:1 |
+| Adobe Systems Incorporated | ADBE | NASDAQ | 44:1 |
+| Adecoagro S.A. | ADGO | NYSE | 1:1 |
+| Analog Devices | ADI | NASDAQ | 15:1 |
+| Automatic Data Processing Inc. | ADP | NASDAQ | 6:1 |
+| Adidas AG | ADS | XETRA | 22:1 |
+| Aegon N.V. | AEG | NYSE | 1:1 |
+| Agnico Eagle Mines Limited | AEM | NYSE | 6:1 |
+| C3.AI INC | AI | NYSE | 5:1 |
+| American International Group (AIG) | AIG | NYSE | 5:1 |
+| Embotelladora Andina S.A. | AKO.B | NYSE | 1:1 |
+| Astera Labs Inc | ALAB | NASDAQ | 44:1 |
+| Applied Materials Inc. | AMAT | NASDAQ | 5:1 |
+| Advanced Micro Devices, Inc. | AMD | NASDAQ | 10:1 |
+| Amgen Inc. | AMGN | NASDAQ | 30:1 |
+| America Movil | AMX | NYSE | 1:1 |
+| Amazon.Com, Inc. | AMZN | NYSE | 144:1 |
+| Arista Networks Inc. | ANET | NYSE | 29:1 |
+| Abercrombie & Fitch Co | ANF | NYSE | 1:1 |
+| Aluminum Corp Of China | AOCA | NYSE | 1:1 |
+| Arcos Dorados Holdings Inc. | ARCO | NYSE | 1:2 |
+| ARK INNOVATION | ARKK | NYSE Arca | 10:1 |
+| ARM Holdings Plc | ARM | NASDAQ | 27:1 |
+| ASML HOLDING NV | ASML | NASDAQ GS | 146:1 |
+| Grupo Aeroportuario Del Sureste, S.A.B. de C.V. | ASR | NYSE | 20:1 |
+| AST SpaceMobile Inc | ASTS | NASDAQ | 15:1 |
+| Pjsc Tatneft | ATAD | LONDON STOCK EXCHANGE | 4:1 |
+| Yamana Gold Inc. | AUY | NYSE | 1:1 |
+| Broadcom Inc. | AVGO | NASDAQ | 39:1 |
+| Avery Dennison Corp. | AVY | NYSE | 18:1 |
+| American Express Co | AXP | NYSE | 15:1 |
+| Astrazeneca Plc | AZN | NYSE | 4:1 |
+| Barrick Gold Corp | B | NYSE | 2:1 |
+| The Boeing Company | BA | NYSE | 24:1 |
+| Bank Of America Corporation | BA.C | NYSE | 4:1 |
+| Alibaba Group Holding Limited | BABA | NYSE | 9:1 |
+| Braskem SA | BAK | NYSE | 2:1 |
+| Basf SE | BAS | FRANKFURT | 2:1 |
+| Bayer AG | BAYN | FRANKFURT | 3:1 |
+| Blackberry Limited | BB | NASDAQ | 3:1 |
+| Banco do Brasil S.A. | BBAS3 | B3 | 2:1 |
+| Banco Bradesco S.A. | BBD | NYSE | 1:1 |
+| Banco Bradesco S.A. | BBDC3 | B3 | 1:1 |
+| Bilbao Vizcaya Argentaria S.A. | BBV | NYSE | 1:1 |
+| Barclays Bank Plc | BCS | NYSE | 1:1 |
+| Bhp Group Ltd | BHP | NYSE | 2:1 |
+| Baidu, Inc. | BIDU | NASDAQ | 11:1 |
+| Biogen Inc. | BIIB | NASDAQ | 13:1 |
+| Bioceres Crop Solutions Corp. | BIOX | NYSE American | 1:1 |
+| The Bank Of New York Mellon Corp. | BK | NYSE | 2:1 |
+| Booking | BKNG | NASDAQ | 700:1 |
+| Baker Hughes Co | BKR | NASDAQ | 7:1 |
+| Bitmine Inmersion Technologies, Inc. | BMNR | NYSE | 8:1 |
+| Bristol-Myers Squibb Company | BMY | NYSE | 3:1 |
+| Bunge Limited | BNG | NYSE | 5:1 |
+| BP PCL | BP | NYSE | 5:1 |
+| Banco BTG Pactual S.A. | BPA11 | B3 | 1:1 |
+| BRF S.A. | BRFS | NYSE | 1:3 |
+| Berkshire Hathaway Inc. | BRKB | NYSE | 22:1 |
+| Banco Santander (Brasil) S.A. | BSBR | NYSE | 1:1 |
+| Danone | BSN | FRANKFURT | 20:1 |
+| Blackstone Inc. | BX | NYSE | 30:1 |
+| Citigroup Inc | C | NYSE | 3:1 |
+| Corporación America Airports S.A. | CAAP | NYSE | 1:4 |
+| Cardinal Health Inc | CAH | NYSE | 3:1 |
+| Canon Inc | CAJ | NYSE | 2:1 |
+| Avis Budget Group Inc. | CAR | NASDAQ | 26:1 |
+| Caterpillar Inc | CAT | NYSE | 20:1 |
+| Companhia Brasileira De Dis NPV ADR | CBRD | NYSE | 1:1 |
+| Cameco Corporation | CCJ | NYSE | 23:1 |
+| Carnival | CCL | NYSE | 3:1 |
+| Coeur Mining Inc. | CDE | NYSE | 1:1 |
+| CONSTELLATION ENERGY CORPORATION | CEG | NASDAQ GS | 45:1 |
+| First Trust NASDAQ Cybersecurity | CIBR | NASDAQ GM | 10:1 |
+| Colgate Palmolive Co | CL | NYSE | 3:1 |
+| CELESTICA INC | CLS | NYSE | 20:1 |
+| Coinbase Global Inc | COIN | NASDAQ | 27:1 |
+| ConocoPhillips | COP | NYSE | 25:1 |
+| Global X Copper Miners ETF | COPX | NYSE | 14:1 |
+| Costco Wholesale Corp | COST | NASDAQ | 48:1 |
+| Salesforce Inc. | CRM | NYSE | 18:1 |
+| CrowdStrike Holdings, Inc. | CRWD | NASDAQ GS | 79:1 |
+| CoreWeave Inc | CRWV | NASDAQ | 27:1 |
+| Credit Suisse Group | CS | NYSE | 1:1 |
+| Cisco Systems Inc | CSCO | NASDAQ | 5:1 |
+| Companhia Siderúrgica Nacional S.A. | CSNA3 | B3 | 1:1 |
+| CVS Health | CVS | NYSE | 15:1 |
+| Chevron Corp. | CVX | NYSE | 16:1 |
+| Cemex S.A.B. de CV | CX | NYSE | 1:1 |
+| Delta Air Lines | DAL | NYSE | 8:1 |
+| Dupont de Nemours Inc. | DD | NYSE | 5:1 |
+| Deere & Co. | DE | NYSE | 40:1 |
+| DECKERS OUTDOOR CORPORATION | DECK | NYSE | 25:1 |
+| Diageo PLC | DEO | NYSE | 6:1 |
+| Danaher Corp | DHR | NYSE | 54:1 |
+| SPDR DOW JONES INDUSTRIAL | DIA | NYSE Arca | 20:1 |
+| The Walt Disney Co. | DISN | NYSE | 12:1 |
+| DocuSign Inc. | DOCU | NASDAQ | 22:1 |
+| DOW Inc | DOW | NYSE | 6:1 |
+| Deutsche Telekom Ag | DTEA | OTC US | 3:1 |
+| Eni Spa | E | NYSE | 4:1 |
+| Electronic Arts Inc | EA | NASDAQ | 14:1 |
+| Ebay Inc. | EBAY | NASDAQ | 2:1 |
+| Centrais Eléctricas Brasileiras S.A. - Eletrobras | EBR | NYSE | 1:4 |
+| Ecolab Inc | ECL | NYSE | 56:1 |
+| ISHARES MSCI EMERGING MARKET | EEM | NYSE Arca | 5:1 |
+| iShares MSCI EAFE ETF | EFA | NYSE | 18:1 |
+| Equifax Inc. | EFX | NYSE | 16:1 |
+| Companhia Paranaense de Energía - COPEL | ELP | NYSE | 1:3 |
+| E.On Se | EOAN | FRANKFURT | 6:1 |
+| Equinor Asa | EQNR | NYSE | 6:1 |
+| Lm Ericsson Telephone Co. | ERIC | NASDAQ | 2:1 |
+| Embraer-Empresa Brasileira de Aeronáutica S.A. | ERJ | NYSE | 1:1 |
+| IShares ESG Aware MSCI USA ETF | ESGU | NASDAQ | 30:1 |
+| ISHARES ETHEREUM TR ETF | ETHA | NASDAQ | 5:1 |
+| Etsy Inc. | ETSY | NASDAQ | 16:1 |
+| iShares MSCI JAPAN ETF | EWJ | NYSE Arca | 14:1 |
+| iShares MSCI South Korea ETF | EWY | NYSE ARCA | 50:1 |
+| ISHARES MSCI BRAZIL CAP | EWZ | NYSE Arca | 2:1 |
+| Ford Motor Company | F | NYSE | 1:1 |
+| Freeport Mcmoran Copper & Gold Inc. | FCX | NYSE | 3:1 |
+| Fedex Corp | FDX | NYSE | 10:1 |
+| Fiserv, Inc. | FISV | NASDAQ GS | 11:1 |
+| Freddie Mac (Federal Home Loan) | FMCC | OTC | 1:1 |
+| Fomento Economico Mexicano - Femsa | FMX | NYSE | 6:1 |
+| Fed. Natl, Mortgage - Fannie Mae | FNMA | OTC | 1:1 |
+| First Solar Inc. | FSLR | NASDAQ | 18:1 |
+| ISHARES CHINA LARGE-CAP ETF | FXI | NYSE | 5:1 |
+| Van Eck Gold Miners ETF/USA | GDX | NYSE | 10:1 |
+| General Electric Co. | GE | NYSE | 8:1 |
+| Gold Fields Ltd. | GFI | NYSE | 1:1 |
+| Gerdau S.A. | GGB | NYSE | 1:4 |
+| Gilead Sciences, Inc. | GILD | NASDAQ | 4:1 |
+| ETF SPDR GOLD TRUST | GLD | NYSE | 50:1 |
+| Golar LNG Ltd. | GLNG | NASDAQ GS | 10:1 |
+| Globant S.A. | GLOB | NYSE | 18:1 |
+| Corning Inc. | GLW | NYSE | 4:1 |
+| General Motors Co | GM | NYSE | 6:1 |
+| Alphabet Inc. | GOOGL | NASDAQ | 58:1 |
+| Geopark Ltd. | GPRK | NYSE | 1:1 |
+| Garmin Ltd. | GRMN | NASDAQ | 3:1 |
+| The Goldman Sachs Group, Inc | GS | NYSE | 13:1 |
+| GSK Plc. | GSK | NYSE | 4:1 |
+| Goodyear Tire & Rubber co./the | GT | NASDAQ | 2:1 |
+| Halliburton Co. | HAL | NYSE | 2:1 |
+| Hapvida Participacoes E Investimentos S.A. | HAPV3 | B3 | 1:1 |
+| The Home Depot Inc. | HD | NYSE | 32:1 |
+| Hdfc Bank Limited. | HDB | NYSE | 2:1 |
+| Hon Hai Precision Industry Co. Ltd. | HHPD | LONDON STOCK EXCHANGE | 2:1 |
+| Hims & Hers Health, Inc. | HIMS | NYSE | 4:1 |
+| Hecla Mining Co. | HL | NYSE | 1:1 |
+| Honda Motor Co. Ltd | HMC | NYSE | 1:1 |
+| Harmony Gold Mining Company Ltd. | HMY | NYSE | 1:1 |
+| Huaneng Power Intl | HNPIY | NYSE | 1:1 |
+| Harley-Davidson Inc. | HOG | NYSE | 3:1 |
+| Honeywell International Inc. | HON | NYSE | 8:1 |
+| Robinhood Markets Inc | HOOD | NASDAQ | 29:1 |
+| Hp Inc | HPQ | NYSE | 1:1 |
+| Hsbc Holdings Plc | HSBC | NYSE | 2:1 |
+| The Hershey Company | HSY | NYSE | 21:1 |
+| Hut 8 Mining Corp. | HUT | NASDAQ GS | 5:1 |
+| Howmet Aerospace Inc. | HWM | NYSE | 1:1 |
+| iShares Nasdaq Biotechnology ETF | IBB | NASDAQ | 27:1 |
+| ISHARES BITCOIN TRUST | IBIT | NASDAQ | 10:1 |
+| International Business Machines | IBM | NYSE | 15:1 |
+| Icici Bank Ltd. | IBN | NYSE | 1:1 |
+| iShares Global Clean Energy ETF | ICLN | NASDAQ GM | 5:1 |
+| iShares Core MSCI Emerging Markets ETF | IEMG | NYSE | 12:1 |
+| iShares Core MSCI Europe ETF | IEUR | NYSE Arca | 11:1 |
+| International Flavors & Fragrances Inc. | IFF | NYSE | 12:1 |
+| iShares CORE S&P MID-CAP ETF | IJH | NYSE Arca | 12:1 |
+| IShares Latin America 40 ETF | ILF | NYSE | 6:1 |
+| Infosys Limited | INFY | NASDAQ | 1:1 |
+| Ing Groep Nv | ING | NYSE | 3:1 |
+| Intel Corporation | INTC | NASDAQ | 5:1 |
+| International Paper Co. | IP | NYSE | 4:1 |
+| Iren Ltd | IREN | NASDAQ | 12:1 |
+| Intuitive Surgical inc | ISRG | NASDAQ | 90:1 |
+| iShares U.S. Aerospace & Defense | ITA | CBOE | 50:1 |
+| Itaú Unibanco Holding S.A. | ITUB | NYSE | 1:1 |
+| Banco Itaú Unibanco S.A | ITUB3 | B3 | 1:1 |
+| iShares S&P 500 Value ETF | IVE | NYSE Arca | 40:1 |
+| IShares Core S&P 500 ETF | IVV | NYSE | 692:1 |
+| iShares S&P 500 Growth ETF | IVW | NYSE Arca | 20:1 |
+| ISHARES TRUST RUSSELL 2000 | IWM | NYSE Arca | 10:1 |
+| Johnson Controls International | JCI | NYSE | 2:1 |
+| Jd.Com, Inc. | JD | NASDAQ | 4:1 |
+| Adr Jumia Technologies Ag | JMIA | NYSE | 1:1 |
+| Johnson & Johnson | JNJ | NYSE | 15:1 |
+| JOYY Inc. | JOYY | NASDAQ | 5:1 |
+| J.P. Morgan & Chase Co. | JPM | NYSE | 15:1 |
+| Kb Financial Group Inc. | KB | NYSE | 2:1 |
+| Bitfarms Ltd. | KEEL | NASDAQ GM | 1:5 |
+| Korea Electric Power Corp. | KEP | NYSE | 1:1 |
+| Kinross Gold Corp | KGC | NYSE | 1:1 |
+| Kimberly-Clark Corp. | KMB | NYSE | 6:1 |
+| The Coca Cola Company | KO | NYSE | 5:1 |
+| Coca-Cola Femsa, S.A.B. De C.V. | KOFM | NYSE | 2:1 |
+| Lithium Americas Corp | LAC | NYSE | 1:1 |
+| Lithium Americas (Argentina) Corp | LAR | NYSE | 1:1 |
+| China Life Insurance | LFC | NYSE | 2:1 |
+| Pjsc Lukoil | LKOD | LONDON STOCK EXCHANGE | 4:1 |
+| Eli Lilly and Company | LLY | NYSE | 56:1 |
+| Lockheed Martin Corporation | LMT | NYSE | 20:1 |
+| Brasilagro - Co Brasileira de Propriedades Agrícolas | LND | NYSE | 1:1 |
+| Lam Research Corp | LRCX | NASDAQ | 56:1 |
+| Lojas Renner S.A. | LREN3 | B3 | 1:1 |
+| Las Vegas Sands Corp | LVS | NYSE | 2:1 |
+| Lloyds Banking Group Plc | LYG | NYSE | 2:1 |
+| Mastercard Inc. | MA | NYSE | 33:1 |
+| Mercedes-Benz Group AG | MBG | FRANKFURT | 4:1 |
+| Mobile Telesystems | MBT | NYSE | 2:1 |
+| Mcdonald'S Corp. | MCD | NYSE | 24:1 |
+| Mondelez | MDLZ | NASDAQ | 15:1 |
+| Medtronic Public Limited Company | MDT | NYSE | 4:1 |
+| Mercadolibre Inc. | MELI | NASDAQ | 120:1 |
+| Meta Platforms Inc | META | NASDAQ | 24:1 |
+| Mizuho Financial Group | MFG | NYSE | 1:1 |
+| Magazine Luiza S.A. | MGLU3 | B3 | 1:1 |
+| Marsh & Mclennan Companies Inc. | MMC | NYSE | 16:1 |
+| 3M Company | MMM | NYSE | 10:1 |
+| Altria Group Inc. | MO | NYSE | 4:1 |
+| The Mosaic Co | MOS | NYSE | 5:1 |
+| MP Materials Corp. | MP | NYSE | 10:1 |
+| Merck & Co. Inc. | MRK | NYSE | 5:1 |
+| Moderna Inc | MRNA | NASDAQ | 19:1 |
+| Marvell Technology Inc | MRVL | NASDAQ | 14:1 |
+| Microsoft Corp. | MSFT | NASDAQ | 30:1 |
+| Motorola Solutions, Inc. | MSI | NYSE | 20:1 |
+| Microstrategy Inc Cl A New | MSTR | NASDAQ GS | 20:1 |
+| Micron Technology Inc | MU | NASDAQ GS | 5:1 |
+| Mitsubishi Ufj Financial Group | MUFG | NYSE | 1:1 |
+| McEwen Mining Inc | MUX | NYSE | 2:1 |
+| NATURA COSMETICOS SA | NATU3 | B3 | 1:1 |
+| Nebius Group N.V. | NBIS | NASDAQ GS | 27:1 |
+| Nec Corporation | NEC1 | FRANKFURT | 1:3 |
+| NextEra Energy, Inc. | NEE | NYSE | 19:1 |
+| Newmont Corporation | NEM | NYSE | 3:1 |
+| Netflix, Inc. | NFLX | NASDAQ | 48:1 |
+| Novagold Resources INC. | NG | NYSE | 1:4 |
+| National Grid Plc | NGG | NYSE | 2:1 |
+| NIO Inc. | NIO | NYSE | 4:1 |
+| Nike Inc. | NKE | NYSE | 12:1 |
+| Novolipetsk Steel PJSC | NLM | LONDON STOCK EXCHANGE | 2:1 |
+| Nomura Holdings, Inc | NMR | NYSE | 1:1 |
+| Nokia Corporation | NOKA | NYSE | 1:1 |
+| SERVICENOW INC | NOW | NYSE | 172:1 |
+| Nissan Motor Co., Ltd | NSAN | OTC US | 1:1 |
+| Netease, Inc | NTES | NASDAQ | 14:1 |
+| Nucor Corp | NUE | NYSE | 16:1 |
+| Nvidia Corporation | NVDA | NASDAQ | 24:1 |
+| NOVO NORDISK A/S | NVO | NYSE | 7:1 |
+| Novartis Ag | NVS | NYSE | 4:1 |
+| Nexgen Energy LTD | NXE | NYSE | 1:1 |
+| Realty Income Corp. | O | NYSE | 13:1 |
+| Pjsc Gazprom | OGZD | LONDON STOCK EXCHANGE | 2:1 |
+| Oklo Inc | OKLO | NYSE | 28:1 |
+| Ondas Holdings Inc. | ONDS | NASDAQ CM | 2:1 |
+| Orange S.A. | ORAN | NYSE | 1:1 |
+| Oracle Corporation | ORCL | NYSE | 3:1 |
+| O'reilly Automotive Inc | ORLY | NASDAQ | 222:1 |
+| Occidental Petroleum Corp. | OXY | NYSE | 5:1 |
+| Pan American Silver Corp. | PAAS | NASDAQ | 3:1 |
+| Grupo Aeroportuario del Pacifico, S.A.B. de C.V. | PAC | NYSE | 16:1 |
+| Pagseguro Digital Ltd | PAGS | NYSE | 3:1 |
+| Palo Alto Networks Inc | PANW | NASDAQ GS | 50:1 |
+| UIPATH INC | PATH | NYSE | 2:1 |
+| Pitney Bowes Inc | PBI | NYSE | 1:1 |
+| Petrobras (ADR) | PBR | NYSE | 1:1 |
+| Paccar Inc. | PCAR | NASDAQ | 3:1 |
+| Panasonic Corporation | PCRF | OTC US | 2:1 |
+| PDD HOLDINGS INC | PDD | NASDAQ GS | 25:1 |
+| Pepsico Inc | PEP | NASDAQ | 18:1 |
+| Petrobras - Petróleo Brasileiro S.A. | PETR3 | B3 | 1:1 |
+| Pfizer Inc. | PFE | NYSE | 4:1 |
+| Procter & Gamble | PG | NYSE | 15:1 |
+| Koninklijke Philips N.V. | PHG | NYSE | 5:1 |
+| Pinterest | PINS | NYSE | 7:1 |
+| Posco Holdings Inc. | PKS | NYSE | 3:1 |
+| Palantir Technologies Inc | PLTR | NYSE | 3:1 |
+| Philip Morris International | PM | NYSE | 18:1 |
+| Petro Rio S.A. | PRIO3 | B3 | 2:1 |
+| Pearson Plc | PSO | NYSE | 1:1 |
+| PROSHARES SHORT QQQ | PSQ | NYSE Arca | 8:1 |
+| Phillips 66 | PSX | NYSE | 6:1 |
+| Petrochina Co Ltd | PTR | NYSE | 4:1 |
+| Paypal Holdings, Inc. | PYPL | NASDAQ | 8:1 |
+| Qualcomm Inc. | QCOM | NASDAQ | 11:1 |
+| INVESCO QQQ TRUST | QQQ | NASDAQ | 20:1 |
+| Ferrari | RACE | NYSE | 83:1 |
+| Roblox Corp. | RBLX | NYSE | 2:1 |
+| Telebras PN | RCTB4 | BOVESPA | 1:1000 |
+| Localiza Rent A Car S.A. | RENT3 | B3 | 2:1 |
+| RIGETTI COMPUTING INC | RGTI | NASDAQ CM | 2:1 |
+| Rio Tinto Plc | RIO | NYSE | 8:1 |
+| Riot Platforms | RIOT | NASDAQ | 3:1 |
+| Rocket Lab Corp | RKLB | NASDAQ | 12:1 |
+| Roku | ROKU | NASDAQ | 13:1 |
+| Ross Stores, Inc. | ROST | NASDAQ | 4:1 |
+| Invesco S&P 500 eql wght ETF | RSP | NYSE ARCA | 30:1 |
+| Raytheon Technologies Corp | RTX | NYSE | 5:1 |
+| Banco Santander S.A | SAN | NYSE | 1:4 |
+| Sap Se | SAP | NYSE | 6:1 |
+| Satellogic Inc. | SATL | NASDAQ GS | 1:1 |
+| Companhia de Saneamento Básico do Estado de São Paulo–Sabesp | SBS | NYSE | 1:2 |
+| Cia Saneamento Básico de SP | SBSP3 | B3 | 1:1 |
+| Starbucks Corporation | SBUX | NASDAQ | 12:1 |
+| Southern Copper Corp | SCCO | NYSE | 2:1 |
+| Charles Schwab | SCHW | NYSE | 13:1 |
+| SunCar Technology Group Inc | SDA | NASDAQ | 2:1 |
+| Sea Ltd. | SE | NYSE | 32:1 |
+| PROSHARES SHORT S&P500 | SH | NYSE | 8:1 |
+| Royal Dutch Shell Plc | SHEL | NYSE | 2:1 |
+| Shopify Inc. | SHOP | NYSE | 107:1 |
+| Shapeways Holdings Inc | SHPW | NYSE | 1:2 |
+| Silvergate Bancorp | SI | NYSE | 10:1 |
+| Companhia Siderúrgica Nacional | SID | NYSE | 1:8 |
+| Siemens Ag Adr | SIEGY | OTC | 3:1 |
+| Schlumberger Ltd | SLB | NYSE | 3:1 |
+| iShares SILVER TRUST | SLV | NYSE Arca | 6:1 |
+| VAN ECK SEMICONDUCTOR ETF | SMH | NASDAQ | 50:1 |
+| Samsung Electronics Co. Ltd. | SMSN | LONDON STOCK EXCHANGE | 14:1 |
+| Snap-On Inc | SNA | NYSE | 6:1 |
+| Snap Inc. | SNAP | NYSE | 1:1 |
+| Sandisk Corporation | SNDK | NASDAQ GS | 170:1 |
+| Snowflake Inc. | SNOW | NYSE | 30:1 |
+| China Petroleum & Chem | SNP | NYSE | 3:1 |
+| Sony Group Corporation | SONY | NYSE | 8:1 |
+| Virgin Galactic | SPCE | NYSE | 1:2 |
+| SPACE EXPLORATION TECHNOLOGIES CORP. | SPCX | NASDAQ GS | 50:1 |
+| S&P Global Inc | SPGI | NYSE | 45:1 |
+| Invesco S&P 500 quality ETF | SPHQ | NYSE ARCA | 14:1 |
+| Spotify Technology S.A. | SPOT | NYSE | 28:1 |
+| DIREXION DAILY S&P 500 BULL 3X | SPXL | NYSE Arca | 25:1 |
+| SPDR S&P 500 | SPY | NYSE Arca | 60:1 |
+| Stellantis | STLA | NYSE | 5:1 |
+| StoneCo Ltd | STNE | NASDAQ | 3:1 |
+| Suzano Papel E Celulose S.A. | SUZ | NYSE | 1:1 |
+| Suzano S.A. | SUZB3 | B3 | 1:1 |
+| Skyworks Solutions | SWKS | NASDAQ | 21:1 |
+| Sysco Corp. | SYY | NYSE | 8:1 |
+| At &T Inc. | T | NYSE | 3:1 |
+| TRIP.COM Group Ltd. | TCOM | NASDAQ | 2:1 |
+| ATLASSIAN CORPORATION | TEAM | NASDAQ GS | 47:1 |
+| Telefonica S.A. | TEFO | NYSE | 8:1 |
+| TEMPUS AI INC | TEM | NASDAQ GS | 12:1 |
+| Tenaris | TEN | NYSE | 1:1 |
+| Target Corporation | TGT | NYSE | 24:1 |
+| Telecom Italia S.P.A. Ordinary Shares | TIIAY | NYSE | 1:1 |
+| Tim Participações S.A. | TIMB | NYSE | 1:1 |
+| TIM S.A. | TIMS3 | B3 | 1:1 |
+| TJX Companies Inc/The | TJX | NYSE | 22:1 |
+| Toyota Motor Corporation | TM | NYSE | 15:1 |
+| Thermo Fisher Scientific Inc. | TMO | NYSE | 22:1 |
+| T-mobile | TMUS | NASDAQ | 33:1 |
+| ProShares UltraPro QQQ | TQQQ | NASDAQ | 25:1 |
+| Tripadvisor, Inc. | TRIP | NASDAQ | 2:1 |
+| The Travelers Cos. Inc. | TRVV | NYSE | 6:1 |
+| Tesla, Inc. | TSLA | NASDAQ | 15:1 |
+| Taiwan Semiconductor Manufacturing | TSM | NYSE | 9:1 |
+| TotalEnergies SE | TTE | NYSE | 3:1 |
+| Tata Motors Ltd | TTM | NYSE | 1:1 |
+| Grupo Televisa S.A. | TV | NYSE | 3:1 |
+| Twilio Inc | TWLO | NYSE | 36:1 |
+| Twitter, Inc. | TWTR | NYSE | 2:1 |
+| Texas Instruments Inc | TXN | NASDAQ | 5:1 |
+| Ternium S.A. | TXR | NYSE | 4:1 |
+| United Airlines Holdings Inc. | UAL | NASDAQ GS | 5:1 |
+| Uber Technologies Inc. | UBER | NYSE | 2:1 |
+| Ultrapar Participações S.A. | UGP | NYSE | 1:1 |
+| Unilever PLC - Sponsored | UL | NYSE | 3:1 |
+| NU Holdings Ltd/Cayman Islands | UN | NYSE | 2:1 |
+| UnitedHealth Group Inc. | UNH | NYSE | 33:1 |
+| Union Pacific Corp. | UNP | NYSE | 20:1 |
+| Upstart Hldgs Inc | UPST | NASDAQ GS | 5:1 |
+| Global X Uranium ETF | URA | NYSE Arca | 5:1 |
+| Urban Outfitters INC. | URBN | NASDAQ | 2:1 |
+| U.S. Bancorp | USB | NYSE | 5:1 |
+| United States Oil Fund | USO | NYSE | 15:1 |
+| Visa Inc | V | NYSE | 18:1 |
+| Vale S.A. | VALE | NYSE | 2:1 |
+| Vale S.A. | VALE3 | B3 | 1:1 |
+| Vanguard FTSE Developed Markets ETF | VEA | NYSE Arca | 10:1 |
+| VANGUARD DIVIDEND APPRECIATION | VIG | NYSE Arca | 39:1 |
+| Vista Energy S.A.B. de C.V. | VIST | NYSE | 3:1 |
+| Telefônica Brasil S.A. | VIV | NYSE | 1:1 |
+| Telefônica Brasil S.A. | VIVT3 | B3 | 1:1 |
+| Vodafone Group Plc | VOD | NASDAQ | 1:1 |
+| Verisign, Inc. | VRSN | - | 6:1 |
+| VERTEX PHARMACEUTICALS INC | VRTX | NYSE | 101:1 |
+| VISTRA CORPORATION | VST | NYSE | 26:1 |
+| iPath Series B S&P 500 VIX | VXX | CBOE | 5:1 |
+| Verizon Communications Inc. | VZ | NYSE | 4:1 |
+| Walgreens Boots Alliance Inc. | WBA | NASDAQ | 3:1 |
+| Weibo Corporation | WBO | NASDAQ | 6:1 |
+| Weg S.A. | WEGE3 | B3 | 1:1 |
+| Wells Fargo & Co. | WFC | NYSE | 5:1 |
+| Walmart Inc. | WMT | NYSE | 18:1 |
+| The Materials Select Sector SPDR Fund | XLB | NYSE Arca | 18:1 |
+| The Communication Services Select Sector SPDR Fund | XLC | NYSE Arca | 19:1 |
+| ENERGY SELECT SECTOR SPDR FUND | XLE | NYSE Arca | 2:1 |
+| FINANCIAL SELECT SECTOR SPDR FUND | XLF | NYSE Arca | 2:1 |
+| The Industrial Select Sector SPDR Fund | XLI | NYSE Arca | 28:1 |
+| The Technology Select Sector SPDR Fund | XLK | NYSE Arca | 46:1 |
+| The Consumer Staples Select Sector SPDR Fund | XLP | NYSE Arca | 16:1 |
+| The Real Estate Select Sector SPDR Fund | XLRE | NYSE Arca | 9:1 |
+| First Trust NASDAQ Cybersecurity | XLU | NASDAQ | 10:1 |
+| Utilities Select Sector SPDR Fund | XLU | NYSE Arca | 15:1 |
+| The Health Care Select Sector SPDR Fund | XLV | NYSE Arca | 29:1 |
+| The Consumer Discretionary Select Sector SPDR Fund | XLY | NYSE Arca | 43:1 |
+| State Street SPDR S&P Metals & Mining ETF | XME | NYSE ARCA | 30:1 |
+| Exxon Mobil Corporation | XOM | NYSE | 10:1 |
+| XP Inc | XP | NASDAQ | 4:1 |
+| XPENG INC | XPEV | New York | 4:1 |
+| Xerox Holding Corporation | XROX | NYSE | 1:1 |
+| Square Inc. | XYZ | NYSE | 20:1 |
+| Yelp Inc. | YELP | NYSE | 2:1 |
+| Yanzhou Coal Mining Co. Ltd. | YZCA | OTC US | 2:1 |
+| Zoom Video Communications Inc. | ZM | NASDAQ | 47:1 |

--- a/doc/CEDEAR.md
+++ b/doc/CEDEAR.md
@@ -20,6 +20,7 @@ El array plano del repo sigue en [`data/cedears.json`](../data/cedears.json).
 Cada entrada del listado contiene:
 - **Cedears**: Símbolo/ticker del CEDEAR
 - **Name**: Nombre completo de la empresa
+- **Market**: Mercado donde cotiza el instrumento subyacente (ej. NYSE, NASDAQ, B3)
 - **Ratio**: Ratio de conversión entre el CEDEAR y la acción subyacente (string)
 
 ### Formatos de `ratio`
@@ -58,6 +59,7 @@ En cualquier celda de la hoja, escribe:
 - "pct_change" - Variación porcentual diaria
 - "name" - Nombre completo de la empresa
 - "ratio" - Ratio de conversión entre el CEDEAR y la acción subyacente
+- "market" - Mercado donde cotiza el subyacente (ej. NYSE, NASDAQ, B3)
 
 ## Ejemplos
 
@@ -68,6 +70,7 @@ En cualquier celda de la hoja, escribe:
 | `=cedear("GOOGL"; "pct_change")` | Variación porcentual diaria del CEDEAR de Google |
 | `=cedear("TSLA"; "name")` | Nombre completo de la empresa Tesla |
 | `=cedear("AMZN"; "ratio")` | Ratio de conversión del CEDEAR de Amazon |
+| `=cedear("AAPL"; "market")` | Mercado donde cotiza Apple (NASDAQ) |
 
 ## Función CedearLista
 
@@ -91,4 +94,4 @@ Esta función devuelve una tabla con todos los CEDEARs disponibles y sus datos a
 "Símbolo inválido: 'xyz'. No se encontró en la lista de CEDEARs disponibles."
 
 **Atributo inválido**  
-"Atributo inválido: 'xyz'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change."
+"Atributo inválido: 'xyz'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market."

--- a/docs/api/cedears.json
+++ b/docs/api/cedears.json
@@ -9,6 +9,7 @@
   "fields": {
     "Cedears": "Ticker del CEDEAR en BYMA",
     "Name": "Nombre de la empresa / instrumento subyacente",
+    "Market": "Mercado donde cotiza el subyacente (ej. NYSE, NASDAQ, B3)",
     "Ratio": "String de conversión. Formato 'N' (ej. \"20\") = N CEDEARs por 1 acción; formato 'A:B' (ej. \"1:3\") = razón A:B. No se normaliza."
   },
   "count": 428,
@@ -16,2141 +17,2569 @@
     {
       "Cedears": "AABA",
       "Name": "Altaba Inc.",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "AAL",
       "Name": "American Airlines Group Inc",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "AAP",
       "Name": "Advanced Auto Parts Inc",
+      "Market": "NYSE",
       "Ratio": "14"
     },
     {
       "Cedears": "AAPL",
       "Name": "Apple Inc.",
+      "Market": "NASDAQ",
       "Ratio": "20"
     },
     {
       "Cedears": "ABBV",
       "Name": "AbbVie Inc.",
+      "Market": "NYSE",
       "Ratio": "10"
     },
     {
       "Cedears": "ABEV",
       "Name": "Ambev S.A.",
+      "Market": "NASDAQ",
       "Ratio": "1:3"
     },
     {
       "Cedears": "ABEV3",
       "Name": "Ambev S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "ABNB",
       "Name": "Airbnb Inc",
+      "Market": "NASDAQ GS",
       "Ratio": "15"
     },
     {
       "Cedears": "ABT",
       "Name": "Abbott Labs",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "ACN",
       "Name": "Accenture",
+      "Market": "NYSE",
       "Ratio": "75"
     },
     {
       "Cedears": "ACWI",
       "Name": "iShares MSCI ACWI ETF",
+      "Market": "NASDAQ",
       "Ratio": "26"
     },
     {
       "Cedears": "ADBE",
       "Name": "Adobe Systems Incorporated",
+      "Market": "NASDAQ",
       "Ratio": "44"
     },
     {
       "Cedears": "ADGO",
       "Name": "Adecoagro S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "ADI",
       "Name": "Analog Devices",
+      "Market": "NASDAQ",
       "Ratio": "15"
     },
     {
       "Cedears": "ADP",
       "Name": "Automatic Data Processing Inc.",
+      "Market": "NASDAQ",
       "Ratio": "6"
     },
     {
       "Cedears": "ADS",
       "Name": "Adidas AG",
+      "Market": "XETRA",
       "Ratio": "22"
     },
     {
       "Cedears": "AEG",
       "Name": "Aegon N.V.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "AEM",
       "Name": "Agnico Eagle Mines Limited",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "AI",
       "Name": "C3.AI INC",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "AIG",
       "Name": "American International Group (AIG)",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "AKO.B",
       "Name": "Embotelladora Andina S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "ALAB",
       "Name": "Astera Labs Inc",
+      "Market": "NASDAQ",
       "Ratio": "44"
     },
     {
       "Cedears": "AMAT",
       "Name": "Applied Materials Inc.",
+      "Market": "NASDAQ",
       "Ratio": "5"
     },
     {
       "Cedears": "AMD",
       "Name": "Advanced Micro Devices, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "10"
     },
     {
       "Cedears": "AMGN",
       "Name": "Amgen Inc.",
+      "Market": "NASDAQ",
       "Ratio": "30"
     },
     {
       "Cedears": "AMX",
       "Name": "America Movil",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "AMZN",
       "Name": "Amazon.Com, Inc.",
+      "Market": "NYSE",
       "Ratio": "144"
     },
     {
       "Cedears": "ANET",
       "Name": "Arista Networks Inc",
+      "Market": "NYSE",
       "Ratio": "29"
     },
     {
       "Cedears": "ANF",
       "Name": "Abercrombie & Fitch Co",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "AOCA",
       "Name": "Aluminum Corp Of China",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "ARCO",
       "Name": "Arcos Dorados Holdings Inc.",
+      "Market": "NYSE",
       "Ratio": "1:2"
     },
     {
       "Cedears": "ARKK",
       "Name": "ARK INNOVATION",
+      "Market": "NYSE Arca",
       "Ratio": "10"
     },
     {
       "Cedears": "ARM",
       "Name": "ARM Holdings Plc",
+      "Market": "NASDAQ",
       "Ratio": "27"
     },
     {
       "Cedears": "ASML",
       "Name": "ASML HOLDING NV",
+      "Market": "NASDAQ GS",
       "Ratio": "146"
     },
     {
       "Cedears": "ASR",
       "Name": "Grupo Aeroportuario Del Sureste, S.A.B. de C.V.",
+      "Market": "NYSE",
       "Ratio": "20"
     },
     {
       "Cedears": "ASTS",
       "Name": "AST SpaceMobile Inc",
+      "Market": "NASDAQ",
       "Ratio": "15"
     },
     {
       "Cedears": "ATAD",
       "Name": "Pjsc Tatneft",
+      "Market": "LONDON STOCK EXCHANGE",
       "Ratio": "4"
     },
     {
       "Cedears": "AUY",
       "Name": "Yamana Gold Inc.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "AVGO",
       "Name": "Broadcom Inc.",
+      "Market": "NASDAQ",
       "Ratio": "39"
     },
     {
       "Cedears": "AVY",
       "Name": "Avery Dennison Corp.",
+      "Market": "NYSE",
       "Ratio": "18"
     },
     {
       "Cedears": "AXP",
       "Name": "American Express Co",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "AZN",
       "Name": "Astrazeneca Plc",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "B",
       "Name": "Barrick Gold Corp",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "BA",
       "Name": "The Boeing Company",
+      "Market": "NYSE",
       "Ratio": "24"
     },
     {
       "Cedears": "BABA",
       "Name": "Alibaba Group Holding Limited",
+      "Market": "NYSE",
       "Ratio": "9"
     },
     {
       "Cedears": "BA.C",
       "Name": "Bank Of America Corporation",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "BAK",
       "Name": "Braskem SA",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "BAS",
       "Name": "Basf SE",
+      "Market": "FRANKFURT",
       "Ratio": "2"
     },
     {
       "Cedears": "BAYN",
       "Name": "Bayer AG",
+      "Market": "FRANKFURT",
       "Ratio": "3"
     },
     {
       "Cedears": "BB",
       "Name": "Blackberry Limited",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "BBAS3",
       "Name": "Banco do Brasil S.A.",
+      "Market": "B3",
       "Ratio": "2"
     },
     {
       "Cedears": "BBD",
       "Name": "Banco Bradesco S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "BBDC3",
       "Name": "Banco Bradesco S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "BBV",
       "Name": "Bilbao Vizcaya Argentaria S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "BCS",
       "Name": "Barclays Bank Plc",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "BHP",
       "Name": "Bhp Group Ltd",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "BIDU",
       "Name": "Baidu, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "11"
     },
     {
       "Cedears": "BIIB",
       "Name": "Biogen Inc.",
+      "Market": "NASDAQ",
       "Ratio": "13"
     },
     {
       "Cedears": "BIOX",
       "Name": "Bioceres Crop Solutions Corp.",
+      "Market": "NYSE American",
       "Ratio": "1"
     },
     {
       "Cedears": "BK",
       "Name": "The Bank Of New York Mellon Corp.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "BKNG",
       "Name": "Booking",
+      "Market": "NASDAQ",
       "Ratio": "700"
     },
     {
       "Cedears": "BKR",
       "Name": "Baker Hughes Co",
+      "Market": "NASDAQ",
       "Ratio": "7"
     },
     {
       "Cedears": "BMNR",
       "Name": "Bitmine Inmersion Technologies, Inc.",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "BMY",
       "Name": "Bristol-Myers Squibb Company",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "BNG",
       "Name": "Bunge Limited",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "BP",
       "Name": "BP PCL",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "BPA11",
       "Name": "Banco BTG Pactual S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "BRFS",
       "Name": "BRF S.A.",
+      "Market": "NYSE",
       "Ratio": "1:3"
     },
     {
       "Cedears": "BRKB",
       "Name": "Berkshire Hathaway Inc.",
+      "Market": "NYSE",
       "Ratio": "22"
     },
     {
       "Cedears": "BSBR",
       "Name": "Banco Santander (Brasil) S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "BSN",
       "Name": "Danone",
+      "Market": "FRANKFURT",
       "Ratio": "20"
     },
     {
       "Cedears": "BX",
       "Name": "Blackstone Inc.",
+      "Market": "NYSE",
       "Ratio": "30"
     },
     {
       "Cedears": "C",
       "Name": "Citigroup Inc",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "CAAP",
       "Name": "Corporación America Airports S.A.",
+      "Market": "NYSE",
       "Ratio": "1:4"
     },
     {
       "Cedears": "CAH",
       "Name": "Cardinal Health Inc",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "CAJ",
       "Name": "Canon Inc",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "CAR",
       "Name": "Avis Budget Group Inc.",
+      "Market": "NASDAQ",
       "Ratio": "26"
     },
     {
       "Cedears": "CAT",
       "Name": "Caterpillar Inc",
+      "Market": "NYSE",
       "Ratio": "20"
     },
     {
       "Cedears": "CBRD",
       "Name": "Companhia Brasileira De Dis NPV ADR",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "CCJ",
       "Name": "Cameco Corporation",
+      "Market": "NYSE",
       "Ratio": "23"
     },
     {
       "Cedears": "CCL",
       "Name": "Carnival",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "CDE",
       "Name": "Coeur Mining Inc.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "CEG",
       "Name": "CONSTELLATION ENERGY CORPORATION",
+      "Market": "NASDAQ GS",
       "Ratio": "45"
     },
     {
       "Cedears": "CIBR",
       "Name": "First Trust NASDAQ Cybersecurity",
+      "Market": "NASDAQ GM",
       "Ratio": "10"
     },
     {
       "Cedears": "CL",
       "Name": "Colgate Palmolive Co",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "CLS",
       "Name": "CELESTICA INC",
+      "Market": "NYSE",
       "Ratio": "20"
     },
     {
       "Cedears": "COIN",
       "Name": "Coinbase Global Inc",
+      "Market": "NASDAQ",
       "Ratio": "27"
     },
     {
       "Cedears": "COP",
       "Name": "ConocoPhillips",
+      "Market": "NYSE",
       "Ratio": "25"
     },
     {
       "Cedears": "COPX",
       "Name": "Global X Copper Miners ETF",
+      "Market": "NYSE",
       "Ratio": "14"
     },
     {
       "Cedears": "COST",
       "Name": "Costco Wholesale Corp",
+      "Market": "NASDAQ",
       "Ratio": "48"
     },
     {
       "Cedears": "CRM",
       "Name": "Salesforce Inc.",
+      "Market": "NYSE",
       "Ratio": "18"
     },
     {
       "Cedears": "CRWD",
       "Name": "CrowdStrike Holdings, Inc.",
+      "Market": "NASDAQ GS",
       "Ratio": "79"
     },
     {
       "Cedears": "CRWV",
       "Name": "CoreWeave Inc",
+      "Market": "NASDAQ",
       "Ratio": "27"
     },
     {
       "Cedears": "CS",
       "Name": "Credit Suisse Group",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "CSCO",
       "Name": "Cisco Systems Inc",
+      "Market": "NASDAQ",
       "Ratio": "5"
     },
     {
       "Cedears": "CSNA3",
       "Name": "Companhia Siderúrgica Nacional S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "CVS",
       "Name": "CVS Health",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "CVX",
       "Name": "Chevron Corp.",
+      "Market": "NYSE",
       "Ratio": "16"
     },
     {
       "Cedears": "CX",
       "Name": "Cemex S.A.B. de CV",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "DAL",
       "Name": "Delta Air Lines",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "DD",
       "Name": "Dupont de Nemours Inc.",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "DE",
       "Name": "Deere & Co.",
+      "Market": "NYSE",
       "Ratio": "40"
     },
     {
       "Cedears": "DECK",
       "Name": "DECKERS OUTDOOR CORPORATION",
+      "Market": "NYSE",
       "Ratio": "25"
     },
     {
       "Cedears": "DEO",
       "Name": "Diageo PLC",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "DHR",
       "Name": "Danaher Corp",
+      "Market": "NYSE",
       "Ratio": "54"
     },
     {
       "Cedears": "DIA",
       "Name": "SPDR DOW JONES INDUSTRIAL",
+      "Market": "NYSE Arca",
       "Ratio": "20"
     },
     {
       "Cedears": "DISN",
       "Name": "The Walt Disney Co.",
+      "Market": "NYSE",
       "Ratio": "12"
     },
     {
       "Cedears": "DOCU",
       "Name": "DocuSign Inc.",
+      "Market": "NASDAQ",
       "Ratio": "22"
     },
     {
       "Cedears": "DOW",
       "Name": "DOW Inc",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "DTEA",
       "Name": "Deutsche Telekom Ag",
+      "Market": "OTC US",
       "Ratio": "3"
     },
     {
       "Cedears": "E",
       "Name": "Eni Spa",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "EA",
       "Name": "Electronic Arts Inc",
+      "Market": "NASDAQ",
       "Ratio": "14"
     },
     {
       "Cedears": "EBAY",
       "Name": "Ebay Inc.",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "EBR",
       "Name": "Centrais Eléctricas Brasileiras S.A. - Eletrobras",
+      "Market": "NYSE",
       "Ratio": "1:4"
     },
     {
       "Cedears": "ECL",
       "Name": "Ecolab Inc",
+      "Market": "NYSE",
       "Ratio": "56"
     },
     {
       "Cedears": "EEM",
       "Name": "ISHARES MSCI EMERGING MARKET",
+      "Market": "NYSE Arca",
       "Ratio": "5"
     },
     {
       "Cedears": "EFA",
       "Name": "iShares MSCI EAFE ETF",
+      "Market": "NYSE",
       "Ratio": "18"
     },
     {
       "Cedears": "EFX",
       "Name": "Equifax Inc.",
+      "Market": "NYSE",
       "Ratio": "16"
     },
     {
       "Cedears": "ELP",
       "Name": "Companhia Paranaense de Energía - COPEL",
+      "Market": "NYSE",
       "Ratio": "1:3"
     },
     {
       "Cedears": "EOAN",
       "Name": "E.On Se",
+      "Market": "FRANKFURT",
       "Ratio": "6"
     },
     {
       "Cedears": "EQNR",
       "Name": "Equinor Asa",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "ERIC",
       "Name": "Lm Ericsson Telephone Co.",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "ERJ",
       "Name": "Embraer-Empresa Brasileira de Aeronáutica S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "ESGU",
       "Name": "IShares ESG Aware MSCI USA ETF",
+      "Market": "NASDAQ",
       "Ratio": "30"
     },
     {
       "Cedears": "ETHA",
       "Name": "ISHARES ETHEREUM TR ETF",
+      "Market": "NASDAQ",
       "Ratio": "5"
     },
     {
       "Cedears": "ETSY",
       "Name": "Etsy Inc.",
+      "Market": "NASDAQ",
       "Ratio": "16"
     },
     {
       "Cedears": "EWJ",
       "Name": "iShares MSCI JAPAN ETF",
+      "Market": "NYSE Arca",
       "Ratio": "14"
     },
     {
       "Cedears": "EWY",
       "Name": "iShares MSCI South Korea ETF",
+      "Market": "NYSE ARCA",
       "Ratio": "50"
     },
     {
       "Cedears": "EWZ",
       "Name": "ISHARES MSCI BRAZIL CAP",
+      "Market": "NYSE Arca",
       "Ratio": "2"
     },
     {
       "Cedears": "F",
       "Name": "Ford Motor Company",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "FCX",
       "Name": "Freeport Mcmoran Copper & Gold Inc.",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "FDX",
       "Name": "Fedex Corp",
+      "Market": "NYSE",
       "Ratio": "10"
     },
     {
       "Cedears": "FISV",
       "Name": "Fiserv, Inc.",
+      "Market": "NASDAQ GS",
       "Ratio": "11"
     },
     {
       "Cedears": "FMCC",
       "Name": "Freddie Mac (Federal Home Loan)",
+      "Market": "OTC",
       "Ratio": "1"
     },
     {
       "Cedears": "FMX",
       "Name": "Fomento Economico Mexicano - Femsa",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "FNMA",
       "Name": "Fed. Natl, Mortgage - Fannie Mae",
+      "Market": "OTC",
       "Ratio": "1"
     },
     {
       "Cedears": "FSLR",
       "Name": "First Solar Inc.",
+      "Market": "NASDAQ",
       "Ratio": "18"
     },
     {
       "Cedears": "FXI",
       "Name": "ISHARES CHINA LARGE-CAP ETF",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "GDX",
       "Name": "Van Eck Gold Miners ETF/USA",
+      "Market": "NYSE",
       "Ratio": "10"
     },
     {
       "Cedears": "GE",
       "Name": "General Electric Co.",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "GFI",
       "Name": "Gold Fields Ltd.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "GGB",
       "Name": "Gerdau S.A.",
+      "Market": "NYSE",
       "Ratio": "1:4"
     },
     {
       "Cedears": "GILD",
       "Name": "Gilead Sciences, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "4"
     },
     {
       "Cedears": "GLD",
       "Name": "ETF SPDR GOLD TRUST",
+      "Market": "NYSE",
       "Ratio": "50"
     },
     {
       "Cedears": "GLNG",
       "Name": "Golar LNG Ltd.",
+      "Market": "NASDAQ GS",
       "Ratio": "10"
     },
     {
       "Cedears": "GLOB",
       "Name": "Globant S.A.",
+      "Market": "NYSE",
       "Ratio": "18"
     },
     {
       "Cedears": "GLW",
       "Name": "Corning Inc.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "GM",
       "Name": "General Motors Co",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "GOOGL",
       "Name": "Alphabet Inc.",
+      "Market": "NASDAQ",
       "Ratio": "58"
     },
     {
       "Cedears": "GPRK",
       "Name": "Geopark Ltd.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "GRMN",
       "Name": "Garmin Ltd.",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "GS",
       "Name": "The Goldman Sachs Group, Inc",
+      "Market": "NYSE",
       "Ratio": "13"
     },
     {
       "Cedears": "GSK",
       "Name": "GSK Plc.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "GT",
       "Name": "Goodyear Tire & Rubber co./the",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "HAL",
       "Name": "Halliburton Co.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "HAPV3",
       "Name": "Hapvida Participacoes E Investimentos S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "HD",
       "Name": "The Home Depot Inc.",
+      "Market": "NYSE",
       "Ratio": "32"
     },
     {
       "Cedears": "HDB",
       "Name": "Hdfc Bank Limited.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "HHPD",
       "Name": "Hon Hai Precision Industry Co. Ltd.",
+      "Market": "LONDON STOCK EXCHANGE",
       "Ratio": "2"
     },
     {
       "Cedears": "HIMS",
       "Name": "Hims & Hers Health, Inc.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "HL",
       "Name": "Hecla Mining Co.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "HMC",
       "Name": "Honda Motor Co. Ltd",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "HMY",
       "Name": "Harmony Gold Mining Company Ltd.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "HNPIY",
       "Name": "Huaneng Power Intl",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "HOG",
       "Name": "Harley-Davidson Inc.",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "HON",
       "Name": "Honeywell International Inc.",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "HOOD",
       "Name": "Robinhood Markets Inc",
+      "Market": "NASDAQ",
       "Ratio": "29"
     },
     {
       "Cedears": "HPQ",
       "Name": "Hp Inc",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "HSBC",
       "Name": "Hsbc Holdings Plc",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "HSY",
       "Name": "The Hershey Company",
+      "Market": "NYSE",
       "Ratio": "21"
     },
     {
       "Cedears": "HUT",
       "Name": "Hut 8 Mining Corp.",
+      "Market": "NASDAQ GS",
       "Ratio": "5"
     },
     {
       "Cedears": "HWM",
       "Name": "Howmet Aerospace Inc.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "IBB",
       "Name": "iShares Nasdaq Biotechnology ETF",
+      "Market": "NASDAQ",
       "Ratio": "27"
     },
     {
       "Cedears": "IBIT",
       "Name": "ISHARES BITCOIN TRUST",
+      "Market": "NASDAQ",
       "Ratio": "10"
     },
     {
       "Cedears": "IBM",
       "Name": "International Business Machines",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "IBN",
       "Name": "Icici Bank Ltd.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "ICLN",
       "Name": "iShares Global Clean Energy ETF",
+      "Market": "NASDAQ GM",
       "Ratio": "5"
     },
     {
       "Cedears": "IEMG",
       "Name": "iShares Core MSCI Emerging Markets ETF",
+      "Market": "NYSE",
       "Ratio": "12"
     },
     {
       "Cedears": "IEUR",
       "Name": "iShares Core MSCI Europe ETF",
+      "Market": "NYSE Arca",
       "Ratio": "11"
     },
     {
       "Cedears": "IFF",
       "Name": "International Flavors & Fragrances Inc.",
+      "Market": "NYSE",
       "Ratio": "12"
     },
     {
       "Cedears": "IJH",
       "Name": "iShares CORE S&P MID-CAP ETF",
+      "Market": "NYSE Arca",
       "Ratio": "12"
     },
     {
       "Cedears": "ILF",
       "Name": "IShares Latin America 40 ETF",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "INFY",
       "Name": "Infosys Limited",
+      "Market": "NASDAQ",
       "Ratio": "1"
     },
     {
       "Cedears": "ING",
       "Name": "Ing Groep Nv",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "INTC",
       "Name": "Intel Corporation",
+      "Market": "NASDAQ",
       "Ratio": "5"
     },
     {
       "Cedears": "IP",
       "Name": "International Paper Co.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "IREN",
       "Name": "Iren Ltd",
+      "Market": "NASDAQ",
       "Ratio": "12"
     },
     {
       "Cedears": "ISRG",
       "Name": "Intuitive Surgical inc",
+      "Market": "NASDAQ",
       "Ratio": "90"
     },
     {
       "Cedears": "ITA",
       "Name": "iShares U.S. Aerospace & Defense",
+      "Market": "CBOE",
       "Ratio": "50"
     },
     {
       "Cedears": "ITUB",
       "Name": "Itaú Unibanco Holding S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "ITUB3",
       "Name": "Banco Itaú Unibanco S.A",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "IVE",
       "Name": "iShares S&P 500 Value ETF",
+      "Market": "NYSE Arca",
       "Ratio": "40"
     },
     {
       "Cedears": "IVV",
       "Name": "IShares Core S&P 500 ETF",
+      "Market": "NYSE",
       "Ratio": "692"
     },
     {
       "Cedears": "IVW",
       "Name": "iShares S&P 500 Growth ETF",
+      "Market": "NYSE Arca",
       "Ratio": "20"
     },
     {
       "Cedears": "IWM",
       "Name": "ISHARES TRUST RUSSELL 2000",
+      "Market": "NYSE Arca",
       "Ratio": "10"
     },
     {
       "Cedears": "JCI",
       "Name": "Johnson Controls International",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "JD",
       "Name": "Jd.Com, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "4"
     },
     {
       "Cedears": "JMIA",
       "Name": "Adr Jumia Technologies Ag",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "JNJ",
       "Name": "Johnson & Johnson",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "JOYY",
       "Name": "JOYY Inc.",
+      "Market": "NASDAQ",
       "Ratio": "5"
     },
     {
       "Cedears": "JPM",
       "Name": "J.P. Morgan & Chase Co.",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "KB",
       "Name": "Kb Financial Group Inc.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "KEEL",
       "Name": "Bitfarms Ltd.",
+      "Market": "NASDAQ GM",
       "Ratio": "1:5"
     },
     {
       "Cedears": "KEP",
       "Name": "Korea Electric Power Corp.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "KGC",
       "Name": "Kinross Gold Corp",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "KMB",
       "Name": "Kimberly-Clark Corp.",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "KO",
       "Name": "The Coca Cola Company",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "KOFM",
       "Name": "Coca-Cola Femsa, S.A.B. De C.V.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "LAC",
       "Name": "Lithium Americas Corp",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "LAR",
       "Name": "Lithium Americas (Argentina) Corp",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "LFC",
       "Name": "China Life Insurance",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "LKOD",
       "Name": "Pjsc Lukoil",
+      "Market": "LONDON STOCK EXCHANGE",
       "Ratio": "4"
     },
     {
       "Cedears": "LLY",
       "Name": "Eli Lilly and Company",
+      "Market": "NYSE",
       "Ratio": "56"
     },
     {
       "Cedears": "LMT",
       "Name": "Lockheed Martin Corporation",
+      "Market": "NYSE",
       "Ratio": "20"
     },
     {
       "Cedears": "LND",
       "Name": "Brasilagro - Co Brasileira de Propriedades Agrícolas",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "LRCX",
       "Name": "Lam Research Corp",
+      "Market": "NASDAQ",
       "Ratio": "56"
     },
     {
       "Cedears": "LREN3",
       "Name": "Lojas Renner S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "LVS",
       "Name": "Las Vegas Sands Corp",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "LYG",
       "Name": "Lloyds Banking Group Plc",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "MA",
       "Name": "Mastercard Inc.",
+      "Market": "NYSE",
       "Ratio": "33"
     },
     {
       "Cedears": "MBG",
       "Name": "Mercedes-Benz Group AG",
+      "Market": "FRANKFURT",
       "Ratio": "4"
     },
     {
       "Cedears": "MBT",
       "Name": "Mobile Telesystems",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "MCD",
       "Name": "Mcdonald'S Corp.",
+      "Market": "NYSE",
       "Ratio": "24"
     },
     {
       "Cedears": "MDLZ",
       "Name": "Mondelez",
+      "Market": "NASDAQ",
       "Ratio": "15"
     },
     {
       "Cedears": "MDT",
       "Name": "Medtronic Public Limited Company",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "MELI",
       "Name": "Mercadolibre Inc.",
+      "Market": "NASDAQ",
       "Ratio": "120"
     },
     {
       "Cedears": "META",
       "Name": "Meta Platforms Inc",
+      "Market": "NASDAQ",
       "Ratio": "24"
     },
     {
       "Cedears": "MFG",
       "Name": "Mizuho Financial Group",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "MGLU3",
       "Name": "Magazine Luiza S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "MMC",
       "Name": "Marsh & Mclennan Companies Inc.",
+      "Market": "NYSE",
       "Ratio": "16"
     },
     {
       "Cedears": "MMM",
       "Name": "3M Company",
+      "Market": "NYSE",
       "Ratio": "10"
     },
     {
       "Cedears": "MO",
       "Name": "Altria Group Inc.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "MOS",
       "Name": "The Mosaic Co",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "MP",
       "Name": "MP Materials Corp.",
+      "Market": "NYSE",
       "Ratio": "10"
     },
     {
       "Cedears": "MRK",
       "Name": "Merck & Co. Inc.",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "MRNA",
       "Name": "Moderna Inc",
+      "Market": "NASDAQ",
       "Ratio": "19"
     },
     {
       "Cedears": "MRVL",
       "Name": "Marvell Technology Inc",
+      "Market": "NASDAQ",
       "Ratio": "14"
     },
     {
       "Cedears": "MSFT",
       "Name": "Microsoft Corp.",
+      "Market": "NASDAQ",
       "Ratio": "30"
     },
     {
       "Cedears": "MSI",
       "Name": "Motorola Solutions, Inc.",
+      "Market": "NYSE",
       "Ratio": "20"
     },
     {
       "Cedears": "MSTR",
       "Name": "Microstrategy Inc Cl A New",
+      "Market": "NASDAQ GS",
       "Ratio": "20"
     },
     {
       "Cedears": "MU",
       "Name": "Micron Technology Inc",
+      "Market": "NASDAQ GS",
       "Ratio": "5"
     },
     {
       "Cedears": "MUFG",
       "Name": "Mitsubishi Ufj Financial Group",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "MUX",
       "Name": "McEwen Mining Inc",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "NATU3",
       "Name": "Natura Cosméticos S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "NBIS",
       "Name": "Nebius Group N.V.",
+      "Market": "NASDAQ GS",
       "Ratio": "27"
     },
     {
       "Cedears": "NEC1",
       "Name": "Nec Corporation",
+      "Market": "FRANKFURT",
       "Ratio": "1:3"
     },
     {
       "Cedears": "NEE",
       "Name": "NextEra Energy, Inc.",
+      "Market": "NYSE",
       "Ratio": "19"
     },
     {
       "Cedears": "NEM",
       "Name": "Newmont Corporation",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "NFLX",
       "Name": "Netflix, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "48"
     },
     {
       "Cedears": "NG",
       "Name": "Novagold Resources INC.",
+      "Market": "NYSE",
       "Ratio": "1:4"
     },
     {
       "Cedears": "NGG",
       "Name": "National Grid Plc",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "NIO",
       "Name": "NIO Inc.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "NKE",
       "Name": "Nike Inc.",
+      "Market": "NYSE",
       "Ratio": "12"
     },
     {
       "Cedears": "NLM",
       "Name": "Novolipetsk Steel PJSC",
+      "Market": "LONDON STOCK EXCHANGE",
       "Ratio": "2"
     },
     {
       "Cedears": "NMR",
       "Name": "Nomura Holdings, Inc",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "NOKA",
       "Name": "Nokia Corporation",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "NOW",
       "Name": "SERVICENOW INC",
+      "Market": "NYSE",
       "Ratio": "172"
     },
     {
       "Cedears": "NSAN",
       "Name": "Nissan Motor Co., Ltd",
+      "Market": "OTC US",
       "Ratio": "1"
     },
     {
       "Cedears": "NTES",
       "Name": "Netease, Inc",
+      "Market": "NASDAQ",
       "Ratio": "14"
     },
     {
       "Cedears": "NUE",
       "Name": "Nucor Corp",
+      "Market": "NYSE",
       "Ratio": "16"
     },
     {
       "Cedears": "NVDA",
       "Name": "Nvidia Corporation",
+      "Market": "NASDAQ",
       "Ratio": "24"
     },
     {
       "Cedears": "NVO",
       "Name": "Novo Nordisk A/S",
+      "Market": "NYSE",
       "Ratio": "7"
     },
     {
       "Cedears": "NVS",
       "Name": "Novartis Ag",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "NXE",
       "Name": "Nexgen Energy LTD",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "O",
       "Name": "Realty Income Corp.",
+      "Market": "NYSE",
       "Ratio": "13"
     },
     {
       "Cedears": "OGZD",
       "Name": "Pjsc Gazprom",
+      "Market": "LONDON STOCK EXCHANGE",
       "Ratio": "2"
     },
     {
       "Cedears": "OKLO",
       "Name": "Oklo Inc",
+      "Market": "NYSE",
       "Ratio": "28"
     },
     {
       "Cedears": "ONDS",
       "Name": "Ondas Holdings Inc.",
+      "Market": "NASDAQ CM",
       "Ratio": "2"
     },
     {
       "Cedears": "ORAN",
       "Name": "Orange S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "ORCL",
       "Name": "Oracle Corporation",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "ORLY",
       "Name": "O'reilly Automotive Inc",
+      "Market": "NASDAQ",
       "Ratio": "222"
     },
     {
       "Cedears": "OXY",
       "Name": "Occidental Petroleum Corp.",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "PAAS",
       "Name": "Pan American Silver Corp.",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "PAC",
       "Name": "Grupo Aeroportuario del Pacifico, S.A.B. de C.V.",
+      "Market": "NYSE",
       "Ratio": "16"
     },
     {
       "Cedears": "PAGS",
       "Name": "Pagseguro Digital Ltd",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "PANW",
       "Name": "Palo Alto Networks Inc",
+      "Market": "NASDAQ GS",
       "Ratio": "50"
     },
     {
       "Cedears": "PATH",
       "Name": "UIPATH INC",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "PBI",
       "Name": "Pitney Bowes Inc",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "PBR",
       "Name": "Petrobras (ADR)",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "PCAR",
       "Name": "Paccar Inc.",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "PCRF",
       "Name": "Panasonic Corporation",
+      "Market": "OTC US",
       "Ratio": "2"
     },
     {
       "Cedears": "PDD",
       "Name": "PDD HOLDINGS INC",
+      "Market": "NASDAQ GS",
       "Ratio": "25"
     },
     {
       "Cedears": "PEP",
       "Name": "Pepsico Inc",
+      "Market": "NASDAQ",
       "Ratio": "18"
     },
     {
       "Cedears": "PETR3",
       "Name": "Petrobras - Petróleo Brasileiro S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "PFE",
       "Name": "Pfizer Inc.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "PG",
       "Name": "Procter & Gamble",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "PHG",
       "Name": "Koninklijke Philips N.V.",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "PINS",
       "Name": "Pinterest",
+      "Market": "NYSE",
       "Ratio": "7"
     },
     {
       "Cedears": "PKS",
       "Name": "Posco Holdings Inc.",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "PLTR",
       "Name": "Palantir Technologies Inc",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "PM",
       "Name": "Philip Morris International",
+      "Market": "NYSE",
       "Ratio": "18"
     },
     {
       "Cedears": "PRIO3",
       "Name": "Petro Rio S.A.",
+      "Market": "B3",
       "Ratio": "2"
     },
     {
       "Cedears": "PSO",
       "Name": "Pearson Plc",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "PSQ",
       "Name": "PROSHARES SHORT QQQ",
+      "Market": "NYSE Arca",
       "Ratio": "8"
     },
     {
       "Cedears": "PSX",
       "Name": "Phillips 66",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "PTR",
       "Name": "Petrochina Co Ltd",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "PYPL",
       "Name": "Paypal Holdings, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "8"
     },
     {
       "Cedears": "QCOM",
       "Name": "Qualcomm Inc.",
+      "Market": "NASDAQ",
       "Ratio": "11"
     },
     {
       "Cedears": "QQQ",
       "Name": "INVESCO QQQ TRUST",
+      "Market": "NASDAQ",
       "Ratio": "20"
     },
     {
       "Cedears": "RACE",
       "Name": "Ferrari",
+      "Market": "NYSE",
       "Ratio": "83"
     },
     {
       "Cedears": "RBLX",
       "Name": "Roblox Corp.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "RCTB4",
       "Name": "Telebras PN",
+      "Market": "BOVESPA",
       "Ratio": "1:1000"
     },
     {
       "Cedears": "RGTI",
       "Name": "RIGETTI COMPUTING INC",
+      "Market": "NASDAQ CM",
       "Ratio": "2"
     },
     {
       "Cedears": "RENT3",
       "Name": "Localiza Rent A Car S.A.",
+      "Market": "B3",
       "Ratio": "2"
     },
     {
       "Cedears": "RIO",
       "Name": "Rio Tinto Plc",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "RIOT",
       "Name": "Riot Platforms",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "RKLB",
       "Name": "Rocket Lab Corp",
+      "Market": "NASDAQ",
       "Ratio": "12"
     },
     {
       "Cedears": "ROKU",
       "Name": "Roku",
+      "Market": "NASDAQ",
       "Ratio": "13"
     },
     {
       "Cedears": "ROST",
       "Name": "Ross Stores, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "4"
     },
     {
       "Cedears": "RSP",
       "Name": "Invesco S&P 500 Equal Weight ETF",
+      "Market": "NYSE ARCA",
       "Ratio": "30"
     },
     {
       "Cedears": "RTX",
       "Name": "Raytheon Technologies Corp",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "SAN",
       "Name": "Banco Santander S.A",
+      "Market": "NYSE",
       "Ratio": "1:4"
     },
     {
       "Cedears": "SAP",
       "Name": "Sap Se",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "SATL",
       "Name": "Satellogic Inc.",
+      "Market": "NASDAQ GS",
       "Ratio": "1"
     },
     {
       "Cedears": "SBS",
       "Name": "Companhia de Saneamento Básico do Estado de São Paulo–Sabesp",
+      "Market": "NYSE",
       "Ratio": "1:2"
     },
     {
       "Cedears": "SBSP3",
       "Name": "Cia Saneamento Básico de SP",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "SBUX",
       "Name": "Starbucks Corporation",
+      "Market": "NASDAQ",
       "Ratio": "12"
     },
     {
       "Cedears": "SCCO",
       "Name": "Southern Copper Corp",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "SCHW",
       "Name": "Charles Schwab",
+      "Market": "NYSE",
       "Ratio": "13"
     },
     {
       "Cedears": "SDA",
       "Name": "SunCar Technology Group Inc",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "SE",
       "Name": "Sea Ltd.",
+      "Market": "NYSE",
       "Ratio": "32"
     },
     {
       "Cedears": "SH",
       "Name": "PROSHARES SHORT S&P500",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "SHEL",
       "Name": "Royal Dutch Shell Plc",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "SHOP",
       "Name": "Shopify Inc.",
+      "Market": "NYSE",
       "Ratio": "107"
     },
     {
       "Cedears": "SHPW",
       "Name": "Shapeways Holdings Inc",
+      "Market": "NYSE",
       "Ratio": "1:2"
     },
     {
       "Cedears": "SI",
       "Name": "Silvergate Bancorp",
+      "Market": "NYSE",
       "Ratio": "10"
     },
     {
       "Cedears": "SID",
       "Name": "Companhia Siderúrgica Nacional",
+      "Market": "NYSE",
       "Ratio": "1:8"
     },
     {
       "Cedears": "SIEGY",
       "Name": "Siemens Ag Adr",
+      "Market": "OTC",
       "Ratio": "3"
     },
     {
       "Cedears": "SLB",
       "Name": "Schlumberger Ltd",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "SLV",
       "Name": "iShares SILVER TRUST",
+      "Market": "NYSE Arca",
       "Ratio": "6"
     },
     {
       "Cedears": "SMH",
       "Name": "VAN ECK SEMICONDUCTOR ETF",
+      "Market": "NASDAQ",
       "Ratio": "50"
     },
     {
       "Cedears": "SMSN",
       "Name": "Samsung Electronics Co. Ltd.",
+      "Market": "LONDON STOCK EXCHANGE",
       "Ratio": "14"
     },
     {
       "Cedears": "SNA",
       "Name": "Snap-On Inc",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "SNAP",
       "Name": "Snap Inc.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "SNDK",
       "Name": "Sandisk Corporation",
+      "Market": "NASDAQ GS",
       "Ratio": "170"
     },
     {
       "Cedears": "SNOW",
       "Name": "Snowflake Inc.",
+      "Market": "NYSE",
       "Ratio": "30"
     },
     {
       "Cedears": "SNP",
       "Name": "China Petroleum & Chem",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "SONY",
       "Name": "Sony Group Corporation",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "SPCE",
       "Name": "Virgin Galactic",
+      "Market": "NYSE",
       "Ratio": "1:2"
     },
     {
       "Cedears": "SPCX",
       "Name": "Space Exploration Technologies Corp.",
+      "Market": "NASDAQ GS",
       "Ratio": "50"
     },
     {
       "Cedears": "SPGI",
       "Name": "S&P Global Inc",
+      "Market": "NYSE",
       "Ratio": "45"
     },
     {
       "Cedears": "SPHQ",
       "Name": "Invesco S&P 500 Quality ETF",
+      "Market": "NYSE ARCA",
       "Ratio": "14"
     },
     {
       "Cedears": "SPOT",
       "Name": "Spotify Technology S.A.",
+      "Market": "NYSE",
       "Ratio": "28"
     },
     {
       "Cedears": "SPXL",
       "Name": "DIREXION DAILY S&P 500 BULL 3X",
+      "Market": "NYSE Arca",
       "Ratio": "25"
     },
     {
       "Cedears": "SPY",
       "Name": "SPDR S&P 500",
+      "Market": "NYSE Arca",
       "Ratio": "60"
     },
     {
       "Cedears": "STLA",
       "Name": "Stellantis",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "STNE",
       "Name": "StoneCo Ltd",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "SUZ",
       "Name": "Suzano Papel E Celulose S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "SUZB3",
       "Name": "Suzano S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "SWKS",
       "Name": "Skyworks Solutions",
+      "Market": "NASDAQ",
       "Ratio": "21"
     },
     {
       "Cedears": "SYY",
       "Name": "Sysco Corp.",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "T",
       "Name": "At &T Inc.",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "TCOM",
       "Name": "TRIP.COM Group Ltd.",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "TEAM",
       "Name": "ATLASSIAN CORPORATION",
+      "Market": "NASDAQ GS",
       "Ratio": "47"
     },
     {
       "Cedears": "TEFO",
       "Name": "Telefonica S.A.",
+      "Market": "NYSE",
       "Ratio": "8"
     },
     {
       "Cedears": "TEM",
       "Name": "TEMPUS AI INC",
+      "Market": "NASDAQ GS",
       "Ratio": "12"
     },
     {
       "Cedears": "TEN",
       "Name": "Tenaris",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "TGT",
       "Name": "Target Corporation",
+      "Market": "NYSE",
       "Ratio": "24"
     },
     {
       "Cedears": "TIIAY",
       "Name": "Telecom Italia S.P.A. Ordinary Shares",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "TIMB",
       "Name": "Tim Participações S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "TIMS3",
       "Name": "TIM S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "TJX",
       "Name": "TJX Companies Inc/The",
+      "Market": "NYSE",
       "Ratio": "22"
     },
     {
       "Cedears": "TM",
       "Name": "Toyota Motor Corporation",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "TMO",
       "Name": "Thermo Fisher Scientific Inc.",
+      "Market": "NYSE",
       "Ratio": "22"
     },
     {
       "Cedears": "TMUS",
       "Name": "T-mobile",
+      "Market": "NASDAQ",
       "Ratio": "33"
     },
     {
       "Cedears": "TQQQ",
       "Name": "ProShares UltraPro QQQ",
+      "Market": "NASDAQ",
       "Ratio": "25"
     },
     {
       "Cedears": "TRIP",
       "Name": "Tripadvisor, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "TRVV",
       "Name": "The Travelers Cos. Inc.",
+      "Market": "NYSE",
       "Ratio": "6"
     },
     {
       "Cedears": "TSLA",
       "Name": "Tesla, Inc.",
+      "Market": "NASDAQ",
       "Ratio": "15"
     },
     {
       "Cedears": "TSM",
       "Name": "Taiwan Semiconductor Manufacturing",
+      "Market": "NYSE",
       "Ratio": "9"
     },
     {
       "Cedears": "TTE",
       "Name": "TotalEnergies SE",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "TTM",
       "Name": "Tata Motors Ltd",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "TV",
       "Name": "Grupo Televisa S.A.",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "TWLO",
       "Name": "Twilio Inc",
+      "Market": "NYSE",
       "Ratio": "36"
     },
     {
       "Cedears": "TWTR",
       "Name": "Twitter, Inc.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "TXN",
       "Name": "Texas Instruments Inc",
+      "Market": "NASDAQ",
       "Ratio": "5"
     },
     {
       "Cedears": "TXR",
       "Name": "Ternium S.A.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "UAL",
       "Name": "United Airlines Holdings Inc.",
+      "Market": "NASDAQ GS",
       "Ratio": "5"
     },
     {
       "Cedears": "UBER",
       "Name": "Uber Technologies Inc.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "UGP",
       "Name": "Ultrapar Participações S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "UL",
       "Name": "Unilever PLC - Sponsored",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "UN",
       "Name": "NU Holdings Ltd/Cayman Islands",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "UNH",
       "Name": "UnitedHealth Group Inc.",
+      "Market": "NYSE",
       "Ratio": "33"
     },
     {
       "Cedears": "UNP",
       "Name": "Union Pacific Corp.",
+      "Market": "NYSE",
       "Ratio": "20"
     },
     {
       "Cedears": "UPST",
       "Name": "Upstart Hldgs Inc",
+      "Market": "NASDAQ GS",
       "Ratio": "5"
     },
     {
       "Cedears": "URA",
       "Name": "Global X Uranium ETF",
+      "Market": "NYSE Arca",
       "Ratio": "5"
     },
     {
       "Cedears": "URBN",
       "Name": "Urban Outfitters INC.",
+      "Market": "NASDAQ",
       "Ratio": "2"
     },
     {
       "Cedears": "USB",
       "Name": "U.S. Bancorp",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "USO",
       "Name": "United States Oil Fund",
+      "Market": "NYSE",
       "Ratio": "15"
     },
     {
       "Cedears": "V",
       "Name": "Visa Inc",
+      "Market": "NYSE",
       "Ratio": "18"
     },
     {
       "Cedears": "VALE",
       "Name": "Vale S.A.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "VALE3",
       "Name": "Vale S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "VEA",
       "Name": "Vanguard FTSE Developed Markets ETF",
+      "Market": "NYSE Arca",
       "Ratio": "10"
     },
     {
       "Cedears": "VIG",
       "Name": "VANGUARD DIVIDEND APPRECIATION",
+      "Market": "NYSE Arca",
       "Ratio": "39"
     },
     {
       "Cedears": "VIST",
       "Name": "Vista Energy S.A.B. de C.V.",
+      "Market": "NYSE",
       "Ratio": "3"
     },
     {
       "Cedears": "VIV",
       "Name": "Telefônica Brasil S.A.",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "VIVT3",
       "Name": "Telefônica Brasil S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "VOD",
       "Name": "Vodafone Group Plc",
+      "Market": "NASDAQ",
       "Ratio": "1"
     },
     {
       "Cedears": "VRSN",
       "Name": "Verisign, Inc.",
+      "Market": "-",
       "Ratio": "6"
     },
     {
       "Cedears": "VRTX",
       "Name": "VERTEX PHARMACEUTICALS INC",
+      "Market": "NYSE",
       "Ratio": "101"
     },
     {
       "Cedears": "VST",
       "Name": "VISTRA CORPORATION",
+      "Market": "NYSE",
       "Ratio": "26"
     },
     {
       "Cedears": "VXX",
       "Name": "iPath Series B S&P 500 VIX",
+      "Market": "CBOE",
       "Ratio": "5"
     },
     {
       "Cedears": "VZ",
       "Name": "Verizon Communications Inc.",
+      "Market": "NYSE",
       "Ratio": "4"
     },
     {
       "Cedears": "WBA",
       "Name": "Walgreens Boots Alliance Inc.",
+      "Market": "NASDAQ",
       "Ratio": "3"
     },
     {
       "Cedears": "WBO",
       "Name": "Weibo Corporation",
+      "Market": "NASDAQ",
       "Ratio": "6"
     },
     {
       "Cedears": "WEGE3",
       "Name": "Weg S.A.",
+      "Market": "B3",
       "Ratio": "1"
     },
     {
       "Cedears": "WFC",
       "Name": "Wells Fargo & Co.",
+      "Market": "NYSE",
       "Ratio": "5"
     },
     {
       "Cedears": "WMT",
       "Name": "Walmart Inc.",
+      "Market": "NYSE",
       "Ratio": "18"
     },
     {
       "Cedears": "XLB",
       "Name": "The Materials Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "18"
     },
     {
       "Cedears": "XLC",
       "Name": "The Communication Services Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "19"
     },
     {
       "Cedears": "XLE",
       "Name": "ENERGY SELECT SECTOR SPDR FUND",
+      "Market": "NYSE Arca",
       "Ratio": "2"
     },
     {
       "Cedears": "XLF",
       "Name": "FINANCIAL SELECT SECTOR SPDR FUND",
+      "Market": "NYSE Arca",
       "Ratio": "2"
     },
     {
       "Cedears": "XLI",
       "Name": "The Industrial Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "28"
     },
     {
       "Cedears": "XLK",
       "Name": "The Technology Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "46"
     },
     {
       "Cedears": "XLP",
       "Name": "The Consumer Staples Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "16"
     },
     {
       "Cedears": "XLRE",
       "Name": "The Real Estate Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "9"
     },
     {
       "Cedears": "XLU",
       "Name": "Utilities Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "15"
     },
     {
       "Cedears": "XLV",
       "Name": "The Health Care Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "29"
     },
     {
       "Cedears": "XME",
       "Name": "State Street SPDR S&P Metals & Mining ETF",
+      "Market": "NYSE ARCA",
       "Ratio": "30"
     },
     {
       "Cedears": "XLY",
       "Name": "The Consumer Discretionary Select Sector SPDR Fund",
+      "Market": "NYSE Arca",
       "Ratio": "43"
     },
     {
       "Cedears": "XOM",
       "Name": "Exxon Mobil Corporation",
+      "Market": "NYSE",
       "Ratio": "10"
     },
     {
       "Cedears": "XP",
       "Name": "XP Inc",
+      "Market": "NASDAQ",
       "Ratio": "4"
     },
     {
       "Cedears": "XPEV",
       "Name": "XPENG INC",
+      "Market": "New York",
       "Ratio": "4"
     },
     {
       "Cedears": "XROX",
       "Name": "Xerox Holding Corporation",
+      "Market": "NYSE",
       "Ratio": "1"
     },
     {
       "Cedears": "XYZ",
       "Name": "Square Inc.",
+      "Market": "NYSE",
       "Ratio": "20"
     },
     {
       "Cedears": "YELP",
       "Name": "Yelp Inc.",
+      "Market": "NYSE",
       "Ratio": "2"
     },
     {
       "Cedears": "YZCA",
       "Name": "Yanzhou Coal Mining Co. Ltd.",
+      "Market": "OTC US",
       "Ratio": "2"
     },
     {
       "Cedears": "ZM",
       "Name": "Zoom Video Communications Inc.",
+      "Market": "NASDAQ",
       "Ratio": "47"
     }
   ]

--- a/scripts/enrich-cedears-market.js
+++ b/scripts/enrich-cedears-market.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Adds the Market field to data/cedears.json from a BYMA markdown table.
+ *
+ * Usage: node scripts/enrich-cedears-market.js [path-to-byma.md]
+ */
+const fs = require('fs');
+const path = require('path');
+
+const bymaPath =
+  process.argv[2] ||
+  path.join(__dirname, '..', 'data', 'cedears_byma.md');
+const cedearsPath = path.join(__dirname, '..', 'data', 'cedears.json');
+
+function normalizeRatio(raw) {
+  const s = String(raw).trim().replace(/\s+/g, '');
+  if (/^\d+$/.test(s)) return s + ':1';
+  return s;
+}
+
+function parseBymaMarkdown(markdown) {
+  const lines = markdown
+    .split('\n')
+    .filter((line) => line.startsWith('|') && !line.includes('---') && !line.includes('Nombre de la'));
+
+  const rows = [];
+  for (const line of lines) {
+    const cols = line.split('|').map((s) => s.trim()).filter(Boolean);
+    if (cols.length < 4) continue;
+    rows.push({
+      code: cols[1].toUpperCase(),
+      market: cols[2],
+      ratio: cols[3].replace(/\s+/g, ''),
+    });
+  }
+  return rows;
+}
+
+function findMarket(bymaRows, item) {
+  const code = item.Cedears.toUpperCase();
+  const targetRatio = normalizeRatio(item.Ratio);
+
+  const exact = bymaRows.filter(
+    (row) => row.code === code && normalizeRatio(row.ratio) === targetRatio
+  );
+  if (exact.length === 1) return exact[0].market;
+  if (exact.length > 1) {
+    throw new Error('Multiple BYMA rows for ' + code + ' with ratio ' + targetRatio);
+  }
+
+  const byCode = bymaRows.filter((row) => row.code === code);
+  if (byCode.length === 1) return byCode[0].market;
+
+  return null;
+}
+
+function main() {
+  const bymaMarkdown = fs.readFileSync(bymaPath, 'utf8');
+  const bymaRows = parseBymaMarkdown(bymaMarkdown);
+  const cedears = JSON.parse(fs.readFileSync(cedearsPath, 'utf8'));
+
+  const missing = [];
+  const enriched = cedears.map((item) => {
+    const market = findMarket(bymaRows, item);
+    if (!market) {
+      missing.push(item.Cedears);
+      return item;
+    }
+    return {
+      Cedears: item.Cedears,
+      Name: item.Name,
+      Market: market,
+      Ratio: item.Ratio,
+    };
+  });
+
+  if (missing.length > 0) {
+    console.error('No BYMA market match for:', missing.join(', '));
+    process.exit(1);
+  }
+
+  fs.writeFileSync(cedearsPath, JSON.stringify(enriched, null, 2) + '\n');
+  console.log('Updated ' + enriched.length + ' CEDEARs with Market field');
+}
+
+main();

--- a/src/cedear.js
+++ b/src/cedear.js
@@ -5,7 +5,8 @@
  * @param {string} value El valor que se quiere obtener: 'c' (precio actual), 'v' (volumen),
  *                      'q_bid' (cantidad bid), 'px_bid' (precio bid), 'px_ask' (precio ask),
  *                      'q_ask' (cantidad ask), 'q_op' (operaciones diarias), 'pct_change' (variación porcentual),
- *                      'name' (nombre completo), 'ratio' (ratio de conversión)
+ *                      'name' (nombre completo), 'ratio' (ratio de conversión),
+ *                      'market' (mercado donde cotiza el subyacente)
  * @return El valor del atributo solicitado para el símbolo especificado.
  * @customfunction
  */
@@ -14,13 +15,13 @@ function cedear(symbol, value) {
     throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
   }
   if (value === undefined || value === null || value === '') {
-    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio.");
+    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market.");
   }
 
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
 
-  var atributosPermitidosJson = ['name', 'ratio'];
+  var atributosPermitidosJson = ['name', 'ratio', 'market'];
 
   if (atributosPermitidosJson.includes(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
@@ -39,7 +40,7 @@ function cedear(symbol, value) {
  * Obtiene datos de CEDEARs desde el archivo JSON local.
  *
  * @param {string} symbol El símbolo del CEDEAR
- * @param {string} attribute El atributo que se quiere obtener ('name' o 'ratio')
+ * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio' o 'market')
  * @return El valor del atributo solicitado
  */
 function buscarCedearEnJson(cedears, symbol, attribute) {
@@ -50,6 +51,8 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
       } else if (attribute === 'ratio') {
         // Se devuelve el string original del JSON ("20" o "1:3"). Ver doc/CEDEAR.md.
         return cedears[i].Ratio;
+      } else if (attribute === 'market') {
+        return cedears[i].Market;
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **Market** field to each CEDEAR entry in `data/cedears.json`, sourced from the official BYMA listing (`data/cedears_byma.md`).

## Changes

- **`data/cedears.json`**: new `Market` field on all 428 entries (e.g. `NASDAQ`, `NYSE`, `B3`, `XETRA`)
- **`data/cedears_byma.md`**: BYMA source table used for enrichment
- **`scripts/enrich-cedears-market.js`**: script to re-apply markets when BYMA updates the list
- **`cedear(symbol, "market")`**: new JSON-backed attribute in `src/cedear.js`
- **`docs/api/cedears.json`**: published API metadata updated via `npm run build`
- **`doc/CEDEAR.md`**: documents the new field and parameter

## Example

```json
{
  "Cedears": "AAPL",
  "Name": "Apple Inc.",
  "Market": "NASDAQ",
  "Ratio": "20"
}
```

## Validation

- `npm run build` and `npm test` pass (36 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c2da594-1024-4596-b073-bfd538c8acbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c2da594-1024-4596-b073-bfd538c8acbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

