### PR TITLE
docs: alinear landing API CEDEARs con campo Market

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Modificado
+- Landing API: ejemplo de respuesta y textos incluyen el campo **`Market`** (mercado del subyacente), alineado a `data/cedears.json` y a `docs/api/cedears.json` tras #26.
+- Catálogo: `=cedear("AAPL";"market")` como ejemplo.
+
 ### Añadido
 - **Hero demo con datos en vivo** (client-side): las 4 celdas de resultado llaman a las mismas APIs públicas que las fórmulas de Sheets, con skeleton mientras cargan.
   - Blue / MEP → [DolarAPI](https://dolarapi.com/v1/dolares)

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Publicada en Pages (sin backend):
 
 | Endpoint | Descripción |
 |----------|-------------|
-| [`/api/cedears.json`](https://ferminrp.github.io/google-sheets-argento/api/cedears.json) | Listado de CEDEARs con `Cedears`, `Name`, `Ratio` + metadata |
+| [`/api/cedears.json`](https://ferminrp.github.io/google-sheets-argento/api/cedears.json) | Listado de CEDEARs con `Cedears`, `Name`, `Market`, `Ratio` + metadata |
 
 Fuente canónica: [`data/cedears.json`](../data/cedears.json) (array plano).  
 `npm run build` regenera `docs/api/cedears.json` con un envelope para agentes/scripts.  

--- a/docs/index.html
+++ b/docs/index.html
@@ -409,8 +409,8 @@
           <div class="catalog-list">
             <div class="catalog-item">
               <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CEDEAR.md" target="_blank" rel="noopener">cedear</a>
-              <span class="desc">CEDEARs: precio, nombre, ratio (+ cedearLista)</span>
-              <span class="example">=cedear("MSFT";"name")</span>
+              <span class="desc">CEDEARs: precio, nombre, ratio, market (+ cedearLista)</span>
+              <span class="example">=cedear("AAPL";"market")</span>
             </div>
             <div class="catalog-item">
               <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/USA_STOCKS.md" target="_blank" rel="noopener">usa_stocks</a>
@@ -492,7 +492,7 @@
           <article class="card">
             <h3>CEDEARs + ratios</h3>
             <p>
-              Listado con ticker, nombre y ratio de conversión.
+              Listado con ticker, nombre, mercado del subyacente y ratio de conversión.
               Ideal para alimentar un agente o un script sin scrapear el PDF de BYMA.
             </p>
             <p style="margin: 0 0 0.75rem;">
@@ -516,11 +516,12 @@
   "fields": {
     "Cedears": "Ticker del CEDEAR en BYMA",
     "Name": "Nombre de la empresa / instrumento subyacente",
+    "Market": "Mercado del subyacente (ej. NYSE, NASDAQ, B3)",
     "Ratio": "String de conversión…"
   },
   "items": [
-    { "Cedears": "AAPL", "Name": "Apple Inc.", "Ratio": "20" },
-    { "Cedears": "ABEV", "Name": "Ambev S.A.", "Ratio": "1:3" }
+    { "Cedears": "AAPL", "Name": "Apple Inc.", "Market": "NASDAQ", "Ratio": "20" },
+    { "Cedears": "ABEV", "Name": "Ambev S.A.", "Market": "NASDAQ", "Ratio": "1:3" }
   ]
 }</pre>
         </div>
@@ -610,7 +611,7 @@ const aapl = items.find((c) => c.Cedears === 'AAPL');</pre>
               </tr>
               <tr>
                 <td class="fn-name">cedears.json</td>
-                <td>Nombres y ratios de CEDEARs (repo + API Pages)</td>
+                <td>Nombres, mercado y ratios de CEDEARs (repo + API Pages)</td>
                 <td>
                   <a href="api/cedears.json">api/cedears.json</a>
                   ·


### PR DESCRIPTION
## Summary
Auditoría post-#26 (`Market` en cada CEDEAR):

| Capa | Estado |
|------|--------|
| `data/cedears.json` | 428 items con `Cedears`, `Name`, `Market`, `Ratio` |
| `docs/api/cedears.json` + Pages live | Ya publican `Market` |
| `=cedear(...;"name"\|"ratio")` | Sin rotura (solo leen esas keys) |
| `=cedear(...;"market")` | Ya expuesto en #26 |
| `npm run build` + `npm test` | Clean / 36 tests OK |

Este PR solo alinea la **landing** (`docs/index.html`, README) cuyo ejemplo de respuesta aún omitía `Market`.

## Test plan
- [x] `npm run build` sin diff en API
- [x] `npm test` green
- [x] raw main + Pages API devuelven Market en AAPL
- [ ] Preview Pages muestra Market en el ejemplo del schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cambios únicamente en markdown/HTML estático; sin lógica, datos ni endpoints.
> 
> **Overview**
> Actualiza la documentación del sitio en **GitHub Pages** para reflejar el campo **`Market`** que ya existía en `data/cedears.json` y en `docs/api/cedears.json` tras #26; la landing seguía mostrando solo ticker, nombre y ratio.
> 
> En **`docs/index.html`** se amplían textos del catálogo (`cedear`), la tarjeta de API, el ejemplo de schema/ítems y la tabla de fuentes, y el ejemplo de fórmula pasa a **`=cedear("AAPL";"market")`**. **`docs/README.md`** lista `Market` en la descripción del endpoint. **`docs/CHANGELOG.md`** registra el cambio bajo [Unreleased].
> 
> No hay cambios en build, datos ni Apps Script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8dfe71bb35ccc4eb8ad9bd8892aa1d65abff8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->