### PR TITLE
feat: históricos OHLC de acciones, CEDEARs y bonos (data912)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This is a **Google Apps Script library** (not a web app/server). Source files in
 
 - **`src/http.js`**: `fetchJson(url, options)` centralizes HTTP (`muteHttpExceptions`, status check, JSON parse) and optional `CacheService.getScriptCache()` via `cacheKey` / `cacheTtlSeconds`.
 - **`src/market_panel.js`**: shared helpers for data912 live panels (`panelCotizacion`, `panelLista`).
+- **`src/market_historico.js`**: shared helpers for data912 OHLC history (`historicoCotizacion` → `ACCIONESHISTORICO` / `CEDEARHISTORICO` / `BONOSHISTORICO`). Full series is not cached (payloads &gt; 90KB); scalar results are cached after lookup.
 - **`src/fecha.js`**: shared date parsing (`YYYY-MM-DD` and Argentine `DD/MM/YYYY`).
 - Public custom functions must use `function name()` declarations (Apps Script hoist); avoid assigning helpers to `const`/`var` if other files call them.
 - Cache is best-effort: values may expire early; payloads &gt; ~90KB are not cached.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Guía paso a paso, catálogo de fórmulas y fuentes de datos: **[sitio web](http
 
 ### Instrumentos financieros argentinos
 - [Acciones](doc/ACCIONES.md) - Información de acciones argentinas
+- [Acciones Histórico](doc/ACCIONES_HISTORICO.md) - OHLC histórico de acciones (data912)
 - [Bonos](doc/BONOS.md) - Información de bonos argentinos
+- [Bonos Histórico](doc/BONOS_HISTORICO.md) - OHLC histórico de bonos (data912)
 - [Letras](doc/LETRAS.md) - Información de letras del tesoro
 - [Opciones](doc/OPCIONES.md) - Información de opciones argentinas
 - [Obligaciones Negociables](doc/OBLIGACIONES.md) - Información de ONs
@@ -32,6 +34,7 @@ Guía paso a paso, catálogo de fórmulas y fuentes de datos: **[sitio web](http
 
 ### Instrumentos financieros internacionales
 - [CEDEAR](doc/CEDEAR.md) - Información de CEDEARs
+- [CEDEAR Histórico](doc/CEDEAR_HISTORICO.md) - OHLC histórico de CEDEARs (data912)
 - [USA Stocks](doc/USA_STOCKS.md) - Información de acciones estadounidenses
 
 ### Indicadores económicos
@@ -71,6 +74,7 @@ Forzar recálculo:
 - [src/dolar_historico.js](src/dolar_historico.js) – Código fuente para cotizaciones históricas de dólar
 - [src/cedear.js](src/cedear.js) – Código fuente para información de CEDEARs
 - [src/acciones.js](src/acciones.js) – Código fuente para información de acciones argentinas
+- [src/market_historico.js](src/market_historico.js) – Helpers de series históricas OHLC (data912)
 - [src/usa_stocks.js](src/usa_stocks.js) – Código fuente para información de acciones estadounidenses
 - [src/bonos.js](src/bonos.js) – Código fuente para información de bonos argentinos
 - [src/letras.js](src/letras.js) – Código fuente para información de letras del tesoro

--- a/all-in-one.js
+++ b/all-in-one.js
@@ -12,6 +12,10 @@ CONSTANTS.ARANCEL_CAUCION_COLOCADORA_TNA = 1.5 / 100;
 CONSTANTS.ARANCEL_CAUCION_TOMADORA_TNA = 4.0 / 100;
 CONSTANTS.HTTP_CACHE_MAX_CHARS = 90000;
 CONSTANTS.HTTP_DEFAULT_TTL = 120;
+CONSTANTS.ATRIBUTOS_HISTORICO = ['o', 'h', 'l', 'c', 'v', 'dr', 'sa'];
+CONSTANTS.SEGMENTOS_HISTORICO = ['stocks', 'cedears', 'bonds'];
+CONSTANTS.HISTORICO_TTL_PASADO = 21600;
+CONSTANTS.HISTORICO_TTL_ULTIMO = 300;
 CONSTANTS.ATRIBUTOS_PANEL = ['c', 'v', 'q_bid', 'px_bid', 'px_ask', 'q_ask', 'q_op', 'pct_change'];
 
 // ================ acciones.js ================
@@ -43,6 +47,20 @@ function ACCIONES(symbol, value) {
  */
 function ACCIONESLISTA() {
   return panelLista('https://data912.com/live/arg_stocks', 'panel:arg_stocks');
+}
+
+/**
+ * Obtiene un valor histórico OHLC de una acción argentina (data912).
+ *
+ * @param {string} symbol Símbolo (ej: 'GGAL', 'YPFD', 'PAMP')
+ * @param {string} fecha [Opcional] 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ *                      Si no hay rueda ese día, usa el último día hábil ≤ fecha.
+ * @param {string} campo [Opcional] o, h, l, c, v, dr, sa. Por defecto: 'c'
+ * @return El valor del campo solicitado
+ * @customfunction
+ */
+function ACCIONESHISTORICO(symbol, fecha, campo) {
+  return historicoCotizacion('stocks', symbol, fecha, campo, 'acciones');
 }
 
 // ================ bcra.js ================
@@ -141,6 +159,20 @@ function BONOS(symbol, value) {
  */
 function BONOSLISTA() {
   return panelLista('https://data912.com/live/arg_bonds', 'panel:arg_bonds');
+}
+
+/**
+ * Obtiene un valor histórico OHLC de un bono argentino (data912).
+ *
+ * @param {string} symbol Símbolo del bono (ej: 'AL30', 'GD30', 'AE38')
+ * @param {string} fecha [Opcional] 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ *                      Si no hay rueda ese día, usa el último día hábil ≤ fecha.
+ * @param {string} campo [Opcional] o, h, l, c, v, dr, sa. Por defecto: 'c'
+ * @return El valor del campo solicitado
+ * @customfunction
+ */
+function BONOSHISTORICO(symbol, fecha, campo) {
+  return historicoCotizacion('bonds', symbol, fecha, campo, 'bonos');
 }
 
 // ================ caucion.js ================
@@ -553,6 +585,20 @@ function getCedearDataFromJson(symbol, attribute) {
  */
 function CEDEARLISTA() {
   return panelLista('https://data912.com/live/arg_cedears', 'panel:arg_cedears');
+}
+
+/**
+ * Obtiene un valor histórico OHLC de un CEDEAR (data912).
+ *
+ * @param {string} symbol Símbolo del CEDEAR (ej: 'AAPL', 'MSFT', 'MELI')
+ * @param {string} fecha [Opcional] 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ *                      Si no hay rueda ese día, usa el último día hábil ≤ fecha.
+ * @param {string} campo [Opcional] o, h, l, c, v, dr, sa. Por defecto: 'c'
+ * @return El valor del campo solicitado
+ * @customfunction
+ */
+function CEDEARHISTORICO(symbol, fecha, campo) {
+  return historicoCotizacion('cedears', symbol, fecha, campo, 'CEDEARs');
 }
 
 // ================ criptoya.js ================
@@ -1352,6 +1398,157 @@ function LETRAS(symbol, valor) {
  */
 function LETRASLISTA() {
   return panelLista('https://data912.com/live/arg_notes', 'panel:arg_notes');
+}
+
+// ================ market_historico.js ================
+/**
+ * Helpers compartidos para series históricas OHLC de data912
+ * (stocks, cedears, bonds).
+ *
+ * Endpoint: GET https://data912.com/historical/{segmento}/{ticker}
+ * Campos: date, o, h, l, c, v, dr, sa
+ *
+ * La API no filtra por fecha: descarga la serie completa. Solo se cachea
+ * el valor escalar resuelto (payloads 100–600KB no entran en CacheService).
+ */
+
+// Constante CONSTANTS.ATRIBUTOS_HISTORICO movida al namespace CONSTANTS
+// var ATRIBUTOS_HISTORICO = ['o', 'h', 'l', 'c', 'v', 'dr', 'sa'];
+// Constante CONSTANTS.SEGMENTOS_HISTORICO movida al namespace CONSTANTS
+// var SEGMENTOS_HISTORICO = ['stocks', 'cedears', 'bonds'];
+// Constante CONSTANTS.HISTORICO_TTL_PASADO movida al namespace CONSTANTS
+// var HISTORICO_TTL_PASADO = 21600; // 6h — EOD no cambia
+// Constante CONSTANTS.HISTORICO_TTL_ULTIMO movida al namespace CONSTANTS
+// var HISTORICO_TTL_ULTIMO = 300;   // 5 min — último bar se mueve
+
+/**
+ * Cotización histórica de un símbolo en un segmento data912.
+ *
+ * @param {string} segmento 'stocks' | 'cedears' | 'bonds'
+ * @param {*} symbol Ticker del instrumento
+ * @param {*} fecha Fecha opcional 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ * @param {*} campo Campo OHLC a devolver (default 'c')
+ * @param {string} nombreMercado Nombre legible para mensajes de error
+ * @return {*} Valor del campo solicitado
+ */
+function historicoCotizacion(segmento, symbol, fecha, campo, nombreMercado) {
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido.");
+  }
+
+  var seg = (segmento || '').toString().toLowerCase().trim();
+  if (CONSTANTS.SEGMENTOS_HISTORICO.indexOf(seg) === -1) {
+    throw new Error(
+      "Segmento histórico inválido: '" + segmento + "'. " +
+      "Segmentos disponibles: " + CONSTANTS.SEGMENTOS_HISTORICO.join(', ') + "."
+    );
+  }
+
+  var simbolo = symbol.toString().toUpperCase().trim();
+  var atributo = (campo === undefined || campo === null || campo === '')
+    ? 'c'
+    : campo.toString().toLowerCase().trim();
+
+  if (CONSTANTS.ATRIBUTOS_HISTORICO.indexOf(atributo) === -1) {
+    throw new Error(
+      "Campo inválido: '" + campo + "'. Campos disponibles: " +
+      CONSTANTS.ATRIBUTOS_HISTORICO.join(', ') + "."
+    );
+  }
+
+  var esUltimo = (fecha === undefined || fecha === null || fecha === '');
+  var fechaISO = null;
+  if (!esUltimo) {
+    try {
+      fechaISO = formatearFechaISO(fecha);
+    } catch (e) {
+      throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
+    }
+  }
+
+  var fechaCacheKey = esUltimo ? 'ultimo' : fechaISO;
+  var scalarKey = 'hist:' + seg + ':' + simbolo + ':' + fechaCacheKey + ':' + atributo;
+  var scalarTtl = esUltimo ? CONSTANTS.HISTORICO_TTL_ULTIMO : CONSTANTS.HISTORICO_TTL_PASADO;
+
+  var cachedScalar = cacheGet_(scalarKey);
+  if (cachedScalar != null) {
+    try {
+      return JSON.parse(cachedScalar);
+    } catch (parseErr) {
+      // cache corrupto: seguir con fetch
+    }
+  }
+
+  var url = 'https://data912.com/historical/' + seg + '/' + encodeURIComponent(simbolo);
+  var datos = fetchJson(url, { skipCache: true });
+
+  if (datos && typeof datos === 'object' && !Array.isArray(datos) && datos.Error) {
+    throw new Error(
+      "Símbolo inválido: '" + symbol + "'. No se encontró en el histórico de " +
+      nombreMercado + "."
+    );
+  }
+
+  if (!datos || !Array.isArray(datos) || !datos.length) {
+    throw new Error(
+      "No se recibieron datos históricos de " + nombreMercado +
+      " para el símbolo '" + symbol + "'."
+    );
+  }
+
+  var barra;
+  if (esUltimo) {
+    barra = datos[datos.length - 1];
+  } else {
+    barra = buscarBarraHistorica_(datos, fechaISO);
+    if (!barra) {
+      throw new Error(
+        "No hay datos históricos de '" + simbolo + "' en o antes de " +
+        fechaISO + "."
+      );
+    }
+  }
+
+  if (barra[atributo] === undefined || barra[atributo] === null) {
+    throw new Error(
+      "El campo '" + atributo + "' no está disponible para '" + simbolo +
+      "' en la fecha " + (barra.date || fechaCacheKey) + "."
+    );
+  }
+
+  var valor = barra[atributo];
+  try {
+    cachePut_(scalarKey, JSON.stringify(valor), scalarTtl);
+  } catch (e) {
+    // cache best-effort
+  }
+  return valor;
+}
+
+/**
+ * Busca la barra con date exacta o el último día hábil ≤ fechaISO.
+ * Asume serie ordenada ascendente por date (como devuelve data912).
+ *
+ * @param {Array} serie
+ * @param {string} fechaISO 'YYYY-MM-DD'
+ * @return {Object|null}
+ */
+function buscarBarraHistorica_(serie, fechaISO) {
+  var mejor = null;
+  for (var i = 0; i < serie.length; i++) {
+    var item = serie[i];
+    if (!item || !item.date) continue;
+    if (item.date === fechaISO) {
+      return item;
+    }
+    if (item.date < fechaISO) {
+      mejor = item;
+    } else if (item.date > fechaISO) {
+      // serie ascendente: no hay más candidatos ≤ fecha
+      break;
+    }
+  }
+  return mejor;
 }
 
 // ================ market_panel.js ================

--- a/doc/ACCIONES.md
+++ b/doc/ACCIONES.md
@@ -48,3 +48,7 @@ Esta función devuelve una tabla con todas las acciones argentinas disponibles y
 
 **Atributo inválido**  
 "Atributo inválido: 'xyz'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change."
+
+## Ver también
+
+- [ACCIONESHISTORICO](ACCIONES_HISTORICO.md) — OHLC histórico (cierre, high/low, volumen, retorno diario)

--- a/doc/ACCIONES_HISTORICO.md
+++ b/doc/ACCIONES_HISTORICO.md
@@ -1,0 +1,53 @@
+# Función ACCIONESHISTORICO
+
+Devuelve un valor histórico OHLC de una acción que cotiza en el mercado argentino (data912).
+
+## Uso
+
+```
+=ACCIONESHISTORICO("symbol")
+=ACCIONESHISTORICO("symbol"; "fecha")
+=ACCIONESHISTORICO("symbol"; "fecha"; "campo")
+```
+
+## Parámetros
+
+**symbol (string):** requerido  
+Símbolo de la acción (ej: `GGAL`, `YPFD`, `PAMP`).
+
+**fecha (string):** opcional  
+Fecha de la rueda en `YYYY-MM-DD` o `DD/MM/YYYY`.  
+Si se omite, usa el **último bar** disponible de la serie.  
+Si no hubo rueda ese día (finde o feriado), usa el **último día hábil ≤ fecha**.
+
+**campo (string):** opcional — por defecto `c`
+
+| Campo | Descripción |
+|-------|-------------|
+| `o` | Open (apertura) |
+| `h` | High (máximo) |
+| `l` | Low (mínimo) |
+| `c` | Close (cierre) |
+| `v` | Volumen nocional |
+| `dr` | Daily return (retorno diario) |
+| `sa` | Sigma anualizada |
+
+## Cómo funciona
+
+Consulta `GET https://data912.com/historical/stocks/{ticker}` (serie completa OHLC).  
+El valor escalar resuelto se cachea en Apps Script (~6 h para fechas pasadas, ~5 min para “último”) para no re-descargar la serie en cada celda con el mismo ticker/fecha/campo.
+
+## Ejemplos
+
+| Fórmula | Descripción |
+|---------|-------------|
+| `=ACCIONESHISTORICO("GGAL")` | Último cierre de Galicia |
+| `=ACCIONESHISTORICO("GGAL"; "2024-01-15")` | Cierre del 15/01/2024 |
+| `=ACCIONESHISTORICO("YPFD"; "15/01/2024"; "h")` | Máximo del día (formato AR) |
+| `=ACCIONESHISTORICO("PAMP"; "2024-01-14"; "c")` | Si el 14 es domingo, devuelve el viernes previo |
+
+## Notas
+
+- Solo disponible para tickers con serie histórica en data912 (panel de acciones AR).
+- La API no filtra por fecha: la primera consulta por ticker descarga toda la serie (puede ser grande).
+- Relacionado: [`ACCIONES`](ACCIONES.md) para cotización live del panel.

--- a/doc/BONOS.md
+++ b/doc/BONOS.md
@@ -42,3 +42,7 @@ Esta función devuelve una tabla con todos los bonos argentinos disponibles y su
 | Fórmula | Descripción |
 |---------|-------------|
 | `=BONOSLISTA()` | Tabla completa de todos los bonos argentinos con sus datos actuales |
+
+## Ver también
+
+- [BONOSHISTORICO](BONOS_HISTORICO.md) — OHLC histórico (cierre, high/low, volumen, retorno diario)

--- a/doc/BONOS_HISTORICO.md
+++ b/doc/BONOS_HISTORICO.md
@@ -1,0 +1,41 @@
+# Función BONOSHISTORICO
+
+Devuelve un valor histórico OHLC de un bono argentino (data912).
+
+## Uso
+
+```
+=BONOSHISTORICO("symbol")
+=BONOSHISTORICO("symbol"; "fecha")
+=BONOSHISTORICO("symbol"; "fecha"; "campo")
+```
+
+## Parámetros
+
+**symbol (string):** requerido  
+Símbolo del bono (ej: `AL30`, `GD30`, `AE38`).
+
+**fecha (string):** opcional  
+`YYYY-MM-DD` o `DD/MM/YYYY`. Sin fecha → último bar.  
+Sin rueda ese día → último día hábil ≤ fecha.
+
+**campo (string):** opcional — por defecto `c`  
+Valores: `o`, `h`, `l`, `c`, `v`, `dr`, `sa` (ver [ACCIONESHISTORICO](ACCIONES_HISTORICO.md)).
+
+## Cómo funciona
+
+Consulta `GET https://data912.com/historical/bonds/{ticker}`.  
+Cache de valor escalar igual que en acciones históricas.
+
+## Ejemplos
+
+| Fórmula | Descripción |
+|---------|-------------|
+| `=BONOSHISTORICO("AL30")` | Último cierre de AL30 |
+| `=BONOSHISTORICO("AL30"; "2024-06-01")` | Cierre del 1/06/2024 |
+| `=BONOSHISTORICO("GD30"; "01/06/2024"; "dr")` | Retorno diario ese día |
+
+## Notas
+
+- Relacionado: [`BONOS`](BONOS.md) para panel live.
+- No hay históricos data912 para letras, ONs u opciones en esta versión.

--- a/doc/CEDEAR.md
+++ b/doc/CEDEAR.md
@@ -95,3 +95,7 @@ Esta función devuelve una tabla con todos los CEDEARs disponibles y sus datos a
 
 **Atributo inválido**  
 "Atributo inválido: 'xyz'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market."
+
+## Ver también
+
+- [CEDEARHISTORICO](CEDEAR_HISTORICO.md) — OHLC histórico (cierre, high/low, volumen, retorno diario)

--- a/doc/CEDEAR_HISTORICO.md
+++ b/doc/CEDEAR_HISTORICO.md
@@ -1,0 +1,40 @@
+# Función CEDEARHISTORICO
+
+Devuelve un valor histórico OHLC de un CEDEAR (data912).
+
+## Uso
+
+```
+=CEDEARHISTORICO("symbol")
+=CEDEARHISTORICO("symbol"; "fecha")
+=CEDEARHISTORICO("symbol"; "fecha"; "campo")
+```
+
+## Parámetros
+
+**symbol (string):** requerido  
+Símbolo del CEDEAR (ej: `AAPL`, `MSFT`, `MELI`).
+
+**fecha (string):** opcional  
+`YYYY-MM-DD` o `DD/MM/YYYY`. Sin fecha → último bar.  
+Sin rueda ese día → último día hábil ≤ fecha.
+
+**campo (string):** opcional — por defecto `c`  
+Valores: `o`, `h`, `l`, `c`, `v`, `dr`, `sa` (ver [ACCIONESHISTORICO](ACCIONES_HISTORICO.md)).
+
+## Cómo funciona
+
+Consulta `GET https://data912.com/historical/cedears/{ticker}`.  
+Cache de valor escalar igual que en acciones históricas.
+
+## Ejemplos
+
+| Fórmula | Descripción |
+|---------|-------------|
+| `=CEDEARHISTORICO("AAPL")` | Último cierre del CEDEAR de Apple |
+| `=CEDEARHISTORICO("AAPL"; "2024-01-15"; "c")` | Cierre del 15/01/2024 |
+| `=CEDEARHISTORICO("MELI"; "15/01/2024"; "v")` | Volumen ese día |
+
+## Notas
+
+- Relacionado: [`CEDEAR`](CEDEAR.md) para panel live, ratio y market.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Añadido
+- Catálogo y ejemplos de **`ACCIONESHISTORICO`**, **`CEDEARHISTORICO`** y **`BONOSHISTORICO`** (OHLC data912).
+- En fuentes: data912 también cubre series históricas OHLC, no solo paneles live.
+
+### Archivos afectados
+- `docs/index.html`
+- `docs/changelog.html`
+- `docs/CHANGELOG.md`
+
+### Decisiones técnicas
+- Funciones nuevas en Apps Script (`src/market_historico.js`); la landing solo documenta el catálogo.
+
 ### Modificado
 - **Breaking:** Todas las funciones públicas (`@customfunction`) usan nomenclatura **UPPERCASE** al estilo de Google Sheets (`DOLAR`, `ACCIONESLISTA`, `DOLARHISTORICO`, `USASTOCKS`, etc.). Los nombres con guión bajo (`dolar_historico`, `usa_stocks`) pasan a concatenación en mayúsculas (`DOLARHISTORICO`, `USASTOCKS`). Google Sheets no distingue mayúsculas/minúsculas, pero sí los guiones bajos: actualizá fórmulas que usaban `dolar_historico` o `usa_stocks`.
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -63,6 +63,19 @@
       <div class="wrap">
 
         <article class="changelog-day">
+          <h2><time datetime="2026-07-10">10 de julio de 2026</time></h2>
+          <ul class="changelog-list">
+            <li>
+              <div class="changelog-item-meta">
+                <span class="cl-tag cl-tag-nuevo">Nuevo</span>
+                <span class="cl-tag cl-tag-datos">Datos</span>
+              </div>
+              <p>Históricos OHLC de mercado vía data912: <code>=ACCIONESHISTORICO</code>, <code>=CEDEARHISTORICO</code> y <code>=BONOSHISTORICO</code> (cierre, high/low, volumen, retorno diario; fallback al último día hábil).</p>
+            </li>
+          </ul>
+        </article>
+
+        <article class="changelog-day">
           <h2><time datetime="2026-07-09">9 de julio de 2026</time></h2>
           <ul class="changelog-list">
             <li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -266,6 +266,10 @@
                 <td>Precio de Galicia</td>
               </tr>
               <tr>
+                <td><code>=ACCIONESHISTORICO("GGAL";"2024-01-15")</code></td>
+                <td>Cierre histórico de Galicia (OHLC data912)</td>
+              </tr>
+              <tr>
                 <td><code>=ACCIONESLISTA()</code></td>
                 <td>Tabla con todo el panel de acciones AR</td>
               </tr>
@@ -274,8 +278,16 @@
                 <td>Variación diaria del AL30</td>
               </tr>
               <tr>
+                <td><code>=BONOSHISTORICO("AL30";"2024-06-01";"dr")</code></td>
+                <td>Retorno diario histórico del AL30</td>
+              </tr>
+              <tr>
                 <td><code>=CEDEAR("AAPL";"c")</code></td>
                 <td>Precio del CEDEAR de Apple</td>
+              </tr>
+              <tr>
+                <td><code>=CEDEARHISTORICO("AAPL";"15/01/2024")</code></td>
+                <td>Cierre histórico del CEDEAR de Apple</td>
               </tr>
               <tr>
                 <td><code>=CEDEAR("AAPL";"ratio")</code></td>
@@ -378,9 +390,19 @@
               <span class="example">=ACCIONES("PAMP";"c")</span>
             </div>
             <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/ACCIONES_HISTORICO.md" target="_blank" rel="noopener">ACCIONESHISTORICO</a>
+              <span class="desc">OHLC histórico de acciones AR (data912)</span>
+              <span class="example">=ACCIONESHISTORICO("GGAL";"2024-01-15")</span>
+            </div>
+            <div class="catalog-item">
               <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/BONOS.md" target="_blank" rel="noopener">BONOS</a>
               <span class="desc">Bonos soberanos y panel completo</span>
               <span class="example">=BONOS("AL30";"c")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/BONOS_HISTORICO.md" target="_blank" rel="noopener">BONOSHISTORICO</a>
+              <span class="desc">OHLC histórico de bonos (data912)</span>
+              <span class="example">=BONOSHISTORICO("AL30";"2024-06-01")</span>
             </div>
             <div class="catalog-item">
               <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/LETRAS.md" target="_blank" rel="noopener">LETRAS</a>
@@ -412,6 +434,11 @@
               <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CEDEAR.md" target="_blank" rel="noopener">CEDEAR</a>
               <span class="desc">CEDEARs: precio, nombre, ratio, market (+ CEDEARLISTA)</span>
               <span class="example">=CEDEAR("AAPL";"market")</span>
+            </div>
+            <div class="catalog-item">
+              <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/CEDEAR_HISTORICO.md" target="_blank" rel="noopener">CEDEARHISTORICO</a>
+              <span class="desc">OHLC histórico de CEDEARs (data912)</span>
+              <span class="example">=CEDEARHISTORICO("AAPL";"15/01/2024")</span>
             </div>
             <div class="catalog-item">
               <a href="https://github.com/ferminrp/google-sheets-argento/blob/main/doc/USA_STOCKS.md" target="_blank" rel="noopener">USASTOCKS</a>
@@ -589,7 +616,7 @@ const aapl = items.find((c) => c.Cedears === 'AAPL');</pre>
               </tr>
               <tr>
                 <td class="fn-name">data912</td>
-                <td>Paneles live: acciones, bonos, letras, opciones, ONs, CEDEARs, USA stocks</td>
+                <td>Paneles live (acciones, bonos, letras, opciones, ONs, CEDEARs, USA stocks) y OHLC histórico (<code>ACCIONESHISTORICO</code>, <code>CEDEARHISTORICO</code>, <code>BONOSHISTORICO</code>)</td>
                 <td>
                   <a href="https://data912.com" target="_blank" rel="noopener">data912.com</a>
                   · <a href="https://x.com/JohnGalt_is_www" target="_blank" rel="noopener">@JohnGalt_is_www</a>

--- a/src/acciones.js
+++ b/src/acciones.js
@@ -27,3 +27,17 @@ function ACCIONES(symbol, value) {
 function ACCIONESLISTA() {
   return panelLista('https://data912.com/live/arg_stocks', 'panel:arg_stocks');
 }
+
+/**
+ * Obtiene un valor histórico OHLC de una acción argentina (data912).
+ *
+ * @param {string} symbol Símbolo (ej: 'GGAL', 'YPFD', 'PAMP')
+ * @param {string} fecha [Opcional] 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ *                      Si no hay rueda ese día, usa el último día hábil ≤ fecha.
+ * @param {string} campo [Opcional] o, h, l, c, v, dr, sa. Por defecto: 'c'
+ * @return El valor del campo solicitado
+ * @customfunction
+ */
+function ACCIONESHISTORICO(symbol, fecha, campo) {
+  return historicoCotizacion('stocks', symbol, fecha, campo, 'acciones');
+}

--- a/src/bonos.js
+++ b/src/bonos.js
@@ -27,3 +27,17 @@ function BONOS(symbol, value) {
 function BONOSLISTA() {
   return panelLista('https://data912.com/live/arg_bonds', 'panel:arg_bonds');
 }
+
+/**
+ * Obtiene un valor histórico OHLC de un bono argentino (data912).
+ *
+ * @param {string} symbol Símbolo del bono (ej: 'AL30', 'GD30', 'AE38')
+ * @param {string} fecha [Opcional] 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ *                      Si no hay rueda ese día, usa el último día hábil ≤ fecha.
+ * @param {string} campo [Opcional] o, h, l, c, v, dr, sa. Por defecto: 'c'
+ * @return El valor del campo solicitado
+ * @customfunction
+ */
+function BONOSHISTORICO(symbol, fecha, campo) {
+  return historicoCotizacion('bonds', symbol, fecha, campo, 'bonos');
+}

--- a/src/cedear.js
+++ b/src/cedear.js
@@ -107,3 +107,17 @@ function getCedearDataFromJson(symbol, attribute) {
 function CEDEARLISTA() {
   return panelLista('https://data912.com/live/arg_cedears', 'panel:arg_cedears');
 }
+
+/**
+ * Obtiene un valor histórico OHLC de un CEDEAR (data912).
+ *
+ * @param {string} symbol Símbolo del CEDEAR (ej: 'AAPL', 'MSFT', 'MELI')
+ * @param {string} fecha [Opcional] 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ *                      Si no hay rueda ese día, usa el último día hábil ≤ fecha.
+ * @param {string} campo [Opcional] o, h, l, c, v, dr, sa. Por defecto: 'c'
+ * @return El valor del campo solicitado
+ * @customfunction
+ */
+function CEDEARHISTORICO(symbol, fecha, campo) {
+  return historicoCotizacion('cedears', symbol, fecha, campo, 'CEDEARs');
+}

--- a/src/market_historico.js
+++ b/src/market_historico.js
@@ -1,0 +1,145 @@
+/**
+ * Helpers compartidos para series históricas OHLC de data912
+ * (stocks, cedears, bonds).
+ *
+ * Endpoint: GET https://data912.com/historical/{segmento}/{ticker}
+ * Campos: date, o, h, l, c, v, dr, sa
+ *
+ * La API no filtra por fecha: descarga la serie completa. Solo se cachea
+ * el valor escalar resuelto (payloads 100–600KB no entran en CacheService).
+ */
+
+var ATRIBUTOS_HISTORICO = ['o', 'h', 'l', 'c', 'v', 'dr', 'sa'];
+var SEGMENTOS_HISTORICO = ['stocks', 'cedears', 'bonds'];
+var HISTORICO_TTL_PASADO = 21600; // 6h — EOD no cambia
+var HISTORICO_TTL_ULTIMO = 300;   // 5 min — último bar se mueve
+
+/**
+ * Cotización histórica de un símbolo en un segmento data912.
+ *
+ * @param {string} segmento 'stocks' | 'cedears' | 'bonds'
+ * @param {*} symbol Ticker del instrumento
+ * @param {*} fecha Fecha opcional 'YYYY-MM-DD' o 'DD/MM/YYYY'. Sin fecha → último bar.
+ * @param {*} campo Campo OHLC a devolver (default 'c')
+ * @param {string} nombreMercado Nombre legible para mensajes de error
+ * @return {*} Valor del campo solicitado
+ */
+function historicoCotizacion(segmento, symbol, fecha, campo, nombreMercado) {
+  if (symbol === undefined || symbol === null || symbol === '') {
+    throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido.");
+  }
+
+  var seg = (segmento || '').toString().toLowerCase().trim();
+  if (SEGMENTOS_HISTORICO.indexOf(seg) === -1) {
+    throw new Error(
+      "Segmento histórico inválido: '" + segmento + "'. " +
+      "Segmentos disponibles: " + SEGMENTOS_HISTORICO.join(', ') + "."
+    );
+  }
+
+  var simbolo = symbol.toString().toUpperCase().trim();
+  var atributo = (campo === undefined || campo === null || campo === '')
+    ? 'c'
+    : campo.toString().toLowerCase().trim();
+
+  if (ATRIBUTOS_HISTORICO.indexOf(atributo) === -1) {
+    throw new Error(
+      "Campo inválido: '" + campo + "'. Campos disponibles: " +
+      ATRIBUTOS_HISTORICO.join(', ') + "."
+    );
+  }
+
+  var esUltimo = (fecha === undefined || fecha === null || fecha === '');
+  var fechaISO = null;
+  if (!esUltimo) {
+    try {
+      fechaISO = formatearFechaISO(fecha);
+    } catch (e) {
+      throw new Error("Fecha inválida: '" + fecha + "'. Usar formato 'YYYY-MM-DD' o 'DD/MM/YYYY'.");
+    }
+  }
+
+  var fechaCacheKey = esUltimo ? 'ultimo' : fechaISO;
+  var scalarKey = 'hist:' + seg + ':' + simbolo + ':' + fechaCacheKey + ':' + atributo;
+  var scalarTtl = esUltimo ? HISTORICO_TTL_ULTIMO : HISTORICO_TTL_PASADO;
+
+  var cachedScalar = cacheGet_(scalarKey);
+  if (cachedScalar != null) {
+    try {
+      return JSON.parse(cachedScalar);
+    } catch (parseErr) {
+      // cache corrupto: seguir con fetch
+    }
+  }
+
+  var url = 'https://data912.com/historical/' + seg + '/' + encodeURIComponent(simbolo);
+  var datos = fetchJson(url, { skipCache: true });
+
+  if (datos && typeof datos === 'object' && !Array.isArray(datos) && datos.Error) {
+    throw new Error(
+      "Símbolo inválido: '" + symbol + "'. No se encontró en el histórico de " +
+      nombreMercado + "."
+    );
+  }
+
+  if (!datos || !Array.isArray(datos) || !datos.length) {
+    throw new Error(
+      "No se recibieron datos históricos de " + nombreMercado +
+      " para el símbolo '" + symbol + "'."
+    );
+  }
+
+  var barra;
+  if (esUltimo) {
+    barra = datos[datos.length - 1];
+  } else {
+    barra = buscarBarraHistorica_(datos, fechaISO);
+    if (!barra) {
+      throw new Error(
+        "No hay datos históricos de '" + simbolo + "' en o antes de " +
+        fechaISO + "."
+      );
+    }
+  }
+
+  if (barra[atributo] === undefined || barra[atributo] === null) {
+    throw new Error(
+      "El campo '" + atributo + "' no está disponible para '" + simbolo +
+      "' en la fecha " + (barra.date || fechaCacheKey) + "."
+    );
+  }
+
+  var valor = barra[atributo];
+  try {
+    cachePut_(scalarKey, JSON.stringify(valor), scalarTtl);
+  } catch (e) {
+    // cache best-effort
+  }
+  return valor;
+}
+
+/**
+ * Busca la barra con date exacta o el último día hábil ≤ fechaISO.
+ * Asume serie ordenada ascendente por date (como devuelve data912).
+ *
+ * @param {Array} serie
+ * @param {string} fechaISO 'YYYY-MM-DD'
+ * @return {Object|null}
+ */
+function buscarBarraHistorica_(serie, fechaISO) {
+  var mejor = null;
+  for (var i = 0; i < serie.length; i++) {
+    var item = serie[i];
+    if (!item || !item.date) continue;
+    if (item.date === fechaISO) {
+      return item;
+    }
+    if (item.date < fechaISO) {
+      mejor = item;
+    } else if (item.date > fechaISO) {
+      // serie ascendente: no hay más candidatos ≤ fecha
+      break;
+    }
+  }
+  return mejor;
+}

--- a/tests/market_historico.test.js
+++ b/tests/market_historico.test.js
@@ -1,0 +1,164 @@
+function createResponse(statusCode, body) {
+  return {
+    getResponseCode: () => statusCode,
+    getContentText: () =>
+      typeof body === 'string' ? body : JSON.stringify(body),
+  };
+}
+
+const SERIE_GGAL = [
+  { date: '2024-01-12', o: 100, h: 110, l: 95, c: 105, v: 1000, dr: 0.01, sa: 0.4 },
+  { date: '2024-01-15', o: 105, h: 120, l: 104, c: 115, v: 2000, dr: 0.095, sa: 0.41 },
+  { date: '2024-01-16', o: 115, h: 118, l: 112, c: 116, v: 1500, dr: 0.009, sa: 0.42 },
+];
+
+describe('históricos de mercado (data912)', () => {
+  let ACCIONESHISTORICO;
+  let CEDEARHISTORICO;
+  let BONOSHISTORICO;
+  let fetchMock;
+  let cacheStore;
+
+  beforeEach(() => {
+    jest.resetModules();
+    fetchMock = jest.fn();
+    cacheStore = new Map();
+
+    global.UrlFetchApp = { fetch: fetchMock };
+    global.Utilities = { formatDate: () => '2024-01-16' };
+    global.DriveApp = {};
+    global.Logger = { log: jest.fn() };
+    global.CacheService = {
+      getScriptCache: () => ({
+        get: (key) => (cacheStore.has(key) ? cacheStore.get(key) : null),
+        put: (key, value) => {
+          cacheStore.set(key, value);
+        },
+      }),
+    };
+
+    ({
+      ACCIONESHISTORICO,
+      CEDEARHISTORICO,
+      BONOSHISTORICO,
+    } = require('./test-wrapper'));
+  });
+
+  afterEach(() => {
+    delete global.UrlFetchApp;
+    delete global.Utilities;
+    delete global.DriveApp;
+    delete global.Logger;
+    delete global.CacheService;
+  });
+
+  test('ACCIONESHISTORICO: match exacto de fecha y campo c por defecto', () => {
+    fetchMock.mockReturnValue(createResponse(200, SERIE_GGAL));
+
+    const result = ACCIONESHISTORICO('ggal', '2024-01-15');
+
+    expect(result).toBe(115);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://data912.com/historical/stocks/GGAL'
+    );
+  });
+
+  test('ACCIONESHISTORICO: campo h y fecha DD/MM/YYYY', () => {
+    fetchMock.mockReturnValue(createResponse(200, SERIE_GGAL));
+
+    const result = ACCIONESHISTORICO('GGAL', '15/01/2024', 'h');
+
+    expect(result).toBe(120);
+  });
+
+  test('ACCIONESHISTORICO: fallback al último día hábil ≤ fecha (finde)', () => {
+    fetchMock.mockReturnValue(createResponse(200, SERIE_GGAL));
+
+    // 2024-01-14 es domingo; última rueda ≤ es 2024-01-12
+    const result = ACCIONESHISTORICO('GGAL', '2024-01-14', 'c');
+
+    expect(result).toBe(105);
+  });
+
+  test('ACCIONESHISTORICO: sin fecha devuelve último bar', () => {
+    fetchMock.mockReturnValue(createResponse(200, SERIE_GGAL));
+
+    const result = ACCIONESHISTORICO('GGAL');
+
+    expect(result).toBe(116);
+  });
+
+  test('CEDEARHISTORICO: usa segmento cedears', () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, [
+        { date: '2024-06-01', o: 1, h: 2, l: 1, c: 1.5, v: 10, dr: 0, sa: 0.3 },
+      ])
+    );
+
+    const result = CEDEARHISTORICO('AAPL', '2024-06-01', 'c');
+
+    expect(result).toBe(1.5);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://data912.com/historical/cedears/AAPL'
+    );
+  });
+
+  test('BONOSHISTORICO: usa segmento bonds y campo dr', () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, [
+        { date: '2024-06-01', o: 50, h: 51, l: 49, c: 50.5, v: 1e6, dr: -0.02, sa: 0.25 },
+      ])
+    );
+
+    const result = BONOSHISTORICO('AL30', '2024-06-01', 'dr');
+
+    expect(result).toBe(-0.02);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://data912.com/historical/bonds/AL30'
+    );
+  });
+
+  test('ticker inválido: body Error de data912', () => {
+    fetchMock.mockReturnValue(
+      createResponse(200, { Error: 'Nahh no tengo ese ticker loko' })
+    );
+
+    expect(() => ACCIONESHISTORICO('NOEXISTE', '2024-01-15')).toThrow(
+      /Símbolo inválido/
+    );
+  });
+
+  test('campo inválido', () => {
+    expect(() => ACCIONESHISTORICO('GGAL', '2024-01-15', 'px_bid')).toThrow(
+      /Campo inválido/
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('símbolo vacío', () => {
+    expect(() => ACCIONESHISTORICO('', '2024-01-15')).toThrow(
+      /Símbolo no proporcionado/
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('fecha anterior a la primera barra', () => {
+    fetchMock.mockReturnValue(createResponse(200, SERIE_GGAL));
+
+    expect(() => ACCIONESHISTORICO('GGAL', '2020-01-01')).toThrow(
+      /No hay datos históricos/
+    );
+  });
+
+  test('cachea el escalar: segunda llamada no re-fetchea', () => {
+    fetchMock.mockReturnValue(createResponse(200, SERIE_GGAL));
+
+    const a = ACCIONESHISTORICO('GGAL', '2024-01-15', 'c');
+    const b = ACCIONESHISTORICO('GGAL', '2024-01-15', 'c');
+
+    expect(a).toBe(115);
+    expect(b).toBe(115);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/test-wrapper.js
+++ b/tests/test-wrapper.js
@@ -43,15 +43,18 @@ const script = new Function('context', `
     ${scriptContent}
     return {
       ACCIONES,
+      ACCIONESHISTORICO,
       ACCIONESLISTA,
       BCRA,
       BCRAVARIABLES,
       BONOS,
+      BONOSHISTORICO,
       BONOSLISTA,
       CAUCIONCOLOCADORA,
       CAUCIONTOMADORA,
       CALCULARCAUCION,
       CEDEAR,
+      CEDEARHISTORICO,
       CRIPTOYA,
       CRYPTO,
       DOLAR,


### PR DESCRIPTION
## Summary
- Nuevas fórmulas `ACCIONESHISTORICO`, `CEDEARHISTORICO` y `BONOSHISTORICO` sobre series OHLC de data912 (`/historical/stocks|cedears|bonds/{ticker}`).
- Helper compartido `src/market_historico.js`: match exacto de fecha, fallback al último día hábil ≤ fecha, último bar si no hay fecha, campos `o/h/l/c/v/dr/sa`.
- Cache del **valor escalar** resuelto (la serie completa no entra en CacheService).
- Docs (`doc/*_HISTORICO.md`), landing, changelog y tests unitarios (47 pasando).

## Uso
```
=ACCIONESHISTORICO("GGAL")
=ACCIONESHISTORICO("GGAL";"2024-01-15")
=ACCIONESHISTORICO("YPFD";"15/01/2024";"h")
=CEDEARHISTORICO("AAPL";"2024-01-15";"c")
=BONOSHISTORICO("AL30";"2024-06-01";"dr")
```

## Test plan
- [x] `npm run build && npm test` (47 tests)
- [ ] Smoke en Google Sheet con `all-in-one.js`: últimos y fecha pasada (incl. finde)
- [ ] Ticker inválido devuelve error legible
- [ ] Verificar catálogo en Pages tras merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive feature but each uncached ticker/date combo can trigger a large UrlFetch to data912, which may stress Apps Script quotas on wide sheets; behavior is covered by unit tests, not live API smoke.
> 
> **Overview**
> Adds **three new Sheet formulas** — `ACCIONESHISTORICO`, `CEDEARHISTORICO`, and `BONOSHISTORICO` — backed by a shared **`market_historico.js`** helper that calls data912 `GET /historical/{stocks|cedears|bonds}/{ticker}`.
> 
> Each call returns one OHLC field (`o/h/l/c/v/dr/sa`, default `c`) for an optional date (`YYYY-MM-DD` or `DD/MM/YYYY`), the **latest bar** if date is omitted, or the **last trading day ≤ date** when the market was closed. The API always returns the full series (not cached in `CacheService` because of size); only the **resolved scalar** is cached (~6h for past dates, ~5 min for “latest”).
> 
> Docs (`doc/*_HISTORICO.md`), README/AGENTS, GitHub Pages catalog/examples/changelog, `all-in-one.js`, and Jest coverage in `tests/market_historico.test.js` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6482a3003a85de21a4f53c651be243c2066d205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->