### PR TITLE
Add TickerOriginal to CEDEARs data

### DIFF
--- a/all-in-one.js
+++ b/all-in-one.js
@@ -485,7 +485,8 @@ function CALCULARCAUCION(
  *                      'q_bid' (cantidad bid), 'px_bid' (precio bid), 'px_ask' (precio ask),
  *                      'q_ask' (cantidad ask), 'q_op' (operaciones diarias), 'pct_change' (variación porcentual),
  *                      'name' (nombre completo), 'ratio' (ratio de conversión),
- *                      'market' (mercado donde cotiza el subyacente)
+ *                      'market' (mercado donde cotiza el subyacente),
+ *                      'ticker_original' (ticker del subyacente en su mercado de origen)
  * @return El valor del atributo solicitado para el símbolo especificado.
  * @customfunction
  */
@@ -494,13 +495,13 @@ function CEDEAR(symbol, value) {
     throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
   }
   if (value === undefined || value === null || value === '') {
-    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market.");
+    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market, ticker_original.");
   }
 
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
 
-  var atributosPermitidosJson = ['name', 'ratio', 'market'];
+  var atributosPermitidosJson = ['name', 'ratio', 'market', 'ticker_original'];
 
   if (atributosPermitidosJson.includes(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
@@ -519,7 +520,7 @@ function CEDEAR(symbol, value) {
  * Obtiene datos de CEDEARs desde el archivo JSON local.
  *
  * @param {string} symbol El símbolo del CEDEAR
- * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio' o 'market')
+ * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio', 'market' o 'ticker_original')
  * @return El valor del atributo solicitado
  */
 function buscarCedearEnJson(cedears, symbol, attribute) {
@@ -532,6 +533,8 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
         return cedears[i].Ratio;
       } else if (attribute === 'market') {
         return cedears[i].Market;
+      } else if (attribute === 'ticker_original') {
+        return cedears[i].TickerOriginal;
       }
     }
   }

--- a/build.js
+++ b/build.js
@@ -147,6 +147,8 @@ function publishCedearsApi() {
             Ratio:
                 "String de conversión. Formato 'N' (ej. \"20\") = N CEDEARs por 1 acción; " +
                 "formato 'A:B' (ej. \"1:3\") = razón A:B. No se normaliza.",
+            TickerOriginal:
+                'Ticker del instrumento subyacente en su mercado de origen (puede diferir del ticker BYMA)',
         },
         count: items.length,
         items: items,

--- a/data/cedears.json
+++ b/data/cedears.json
@@ -3,2568 +3,2996 @@
     "Cedears": "AABA",
     "Name": "Altaba Inc.",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "AABA"
   },
   {
     "Cedears": "AAL",
     "Name": "American Airlines Group Inc",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "AAL"
   },
   {
     "Cedears": "AAP",
     "Name": "Advanced Auto Parts Inc",
     "Market": "NYSE",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "AAP"
   },
   {
     "Cedears": "AAPL",
     "Name": "Apple Inc.",
     "Market": "NASDAQ",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "AAPL"
   },
   {
     "Cedears": "ABBV",
     "Name": "AbbVie Inc.",
     "Market": "NYSE",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "ABBV"
   },
   {
     "Cedears": "ABEV",
     "Name": "Ambev S.A.",
     "Market": "NASDAQ",
-    "Ratio": "1:3"
+    "Ratio": "1:3",
+    "TickerOriginal": "ABEV"
   },
   {
     "Cedears": "ABEV3",
     "Name": "Ambev S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "ABEV3"
   },
   {
     "Cedears": "ABNB",
     "Name": "Airbnb Inc",
     "Market": "NASDAQ GS",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "ABNB"
   },
   {
     "Cedears": "ABT",
     "Name": "Abbott Labs",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "ABT"
   },
   {
     "Cedears": "ACN",
     "Name": "Accenture",
     "Market": "NYSE",
-    "Ratio": "75"
+    "Ratio": "75",
+    "TickerOriginal": "ACN"
   },
   {
     "Cedears": "ACWI",
     "Name": "iShares MSCI ACWI ETF",
     "Market": "NASDAQ",
-    "Ratio": "26"
+    "Ratio": "26",
+    "TickerOriginal": "ACWI"
   },
   {
     "Cedears": "ADBE",
     "Name": "Adobe Systems Incorporated",
     "Market": "NASDAQ",
-    "Ratio": "44"
+    "Ratio": "44",
+    "TickerOriginal": "ADBE"
   },
   {
     "Cedears": "ADGO",
     "Name": "Adecoagro S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "AGRO"
   },
   {
     "Cedears": "ADI",
     "Name": "Analog Devices",
     "Market": "NASDAQ",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "ADI"
   },
   {
     "Cedears": "ADP",
     "Name": "Automatic Data Processing Inc.",
     "Market": "NASDAQ",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "ADP"
   },
   {
     "Cedears": "ADS",
     "Name": "Adidas AG",
     "Market": "XETRA",
-    "Ratio": "22"
+    "Ratio": "22",
+    "TickerOriginal": "ADS"
   },
   {
     "Cedears": "AEG",
     "Name": "Aegon N.V.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "AEG"
   },
   {
     "Cedears": "AEM",
     "Name": "Agnico Eagle Mines Limited",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "AEM"
   },
   {
     "Cedears": "AI",
     "Name": "C3.AI INC",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "AI"
   },
   {
     "Cedears": "AIG",
     "Name": "American International Group (AIG)",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "AIG"
   },
   {
     "Cedears": "AKO.B",
     "Name": "Embotelladora Andina S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "AKO.B"
   },
   {
     "Cedears": "ALAB",
     "Name": "Astera Labs Inc",
     "Market": "NASDAQ",
-    "Ratio": "44"
+    "Ratio": "44",
+    "TickerOriginal": "ALAB"
   },
   {
     "Cedears": "AMAT",
     "Name": "Applied Materials Inc.",
     "Market": "NASDAQ",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "AMAT"
   },
   {
     "Cedears": "AMD",
     "Name": "Advanced Micro Devices, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "AMD"
   },
   {
     "Cedears": "AMGN",
     "Name": "Amgen Inc.",
     "Market": "NASDAQ",
-    "Ratio": "30"
+    "Ratio": "30",
+    "TickerOriginal": "AMGN"
   },
   {
     "Cedears": "AMX",
     "Name": "America Movil",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "AMX"
   },
   {
     "Cedears": "AMZN",
     "Name": "Amazon.Com, Inc.",
     "Market": "NYSE",
-    "Ratio": "144"
+    "Ratio": "144",
+    "TickerOriginal": "AMZN"
   },
   {
     "Cedears": "ANET",
     "Name": "Arista Networks Inc",
     "Market": "NYSE",
-    "Ratio": "29"
+    "Ratio": "29",
+    "TickerOriginal": "ANET"
   },
   {
     "Cedears": "ANF",
     "Name": "Abercrombie & Fitch Co",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "ANF"
   },
   {
     "Cedears": "AOCA",
     "Name": "Aluminum Corp Of China",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "ACH"
   },
   {
     "Cedears": "ARCO",
     "Name": "Arcos Dorados Holdings Inc.",
     "Market": "NYSE",
-    "Ratio": "1:2"
+    "Ratio": "1:2",
+    "TickerOriginal": "ARCO"
   },
   {
     "Cedears": "ARKK",
     "Name": "ARK INNOVATION",
     "Market": "NYSE Arca",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "ARKK"
   },
   {
     "Cedears": "ARM",
     "Name": "ARM Holdings Plc",
     "Market": "NASDAQ",
-    "Ratio": "27"
+    "Ratio": "27",
+    "TickerOriginal": "ARM"
   },
   {
     "Cedears": "ASML",
     "Name": "ASML HOLDING NV",
     "Market": "NASDAQ GS",
-    "Ratio": "146"
+    "Ratio": "146",
+    "TickerOriginal": "ASML"
   },
   {
     "Cedears": "ASR",
     "Name": "Grupo Aeroportuario Del Sureste, S.A.B. de C.V.",
     "Market": "NYSE",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "ASR"
   },
   {
     "Cedears": "ASTS",
     "Name": "AST SpaceMobile Inc",
     "Market": "NASDAQ",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "ASTS"
   },
   {
     "Cedears": "ATAD",
     "Name": "Pjsc Tatneft",
     "Market": "LONDON STOCK EXCHANGE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "ATAD"
   },
   {
     "Cedears": "AUY",
     "Name": "Yamana Gold Inc.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "AUY"
   },
   {
     "Cedears": "AVGO",
     "Name": "Broadcom Inc.",
     "Market": "NASDAQ",
-    "Ratio": "39"
+    "Ratio": "39",
+    "TickerOriginal": "AVGO"
   },
   {
     "Cedears": "AVY",
     "Name": "Avery Dennison Corp.",
     "Market": "NYSE",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "AVY"
   },
   {
     "Cedears": "AXP",
     "Name": "American Express Co",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "AXP"
   },
   {
     "Cedears": "AZN",
     "Name": "Astrazeneca Plc",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "AZN"
   },
   {
     "Cedears": "B",
     "Name": "Barrick Gold Corp",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "B"
   },
   {
     "Cedears": "BA",
     "Name": "The Boeing Company",
     "Market": "NYSE",
-    "Ratio": "24"
+    "Ratio": "24",
+    "TickerOriginal": "BA"
   },
   {
     "Cedears": "BABA",
     "Name": "Alibaba Group Holding Limited",
     "Market": "NYSE",
-    "Ratio": "9"
+    "Ratio": "9",
+    "TickerOriginal": "BABA"
   },
   {
     "Cedears": "BA.C",
     "Name": "Bank Of America Corporation",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "BAC"
   },
   {
     "Cedears": "BAK",
     "Name": "Braskem SA",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "BAK"
   },
   {
     "Cedears": "BAS",
     "Name": "Basf SE",
     "Market": "FRANKFURT",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "BAS"
   },
   {
     "Cedears": "BAYN",
     "Name": "Bayer AG",
     "Market": "FRANKFURT",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "BAYN"
   },
   {
     "Cedears": "BB",
     "Name": "Blackberry Limited",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "BB"
   },
   {
     "Cedears": "BBAS3",
     "Name": "Banco do Brasil S.A.",
     "Market": "B3",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "BBAS3"
   },
   {
     "Cedears": "BBD",
     "Name": "Banco Bradesco S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "BBD"
   },
   {
     "Cedears": "BBDC3",
     "Name": "Banco Bradesco S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "BBDC3"
   },
   {
     "Cedears": "BBV",
     "Name": "Bilbao Vizcaya Argentaria S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "BBV"
   },
   {
     "Cedears": "BCS",
     "Name": "Barclays Bank Plc",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "BCS"
   },
   {
     "Cedears": "BHP",
     "Name": "Bhp Group Ltd",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "BHP"
   },
   {
     "Cedears": "BIDU",
     "Name": "Baidu, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "11"
+    "Ratio": "11",
+    "TickerOriginal": "BIDU"
   },
   {
     "Cedears": "BIIB",
     "Name": "Biogen Inc.",
     "Market": "NASDAQ",
-    "Ratio": "13"
+    "Ratio": "13",
+    "TickerOriginal": "BIIB"
   },
   {
     "Cedears": "BIOX",
     "Name": "Bioceres Crop Solutions Corp.",
     "Market": "NYSE American",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "BIOX"
   },
   {
     "Cedears": "BK",
     "Name": "The Bank Of New York Mellon Corp.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "BK"
   },
   {
     "Cedears": "BKNG",
     "Name": "Booking",
     "Market": "NASDAQ",
-    "Ratio": "700"
+    "Ratio": "700",
+    "TickerOriginal": "BKNG"
   },
   {
     "Cedears": "BKR",
     "Name": "Baker Hughes Co",
     "Market": "NASDAQ",
-    "Ratio": "7"
+    "Ratio": "7",
+    "TickerOriginal": "BKR"
   },
   {
     "Cedears": "BMNR",
     "Name": "Bitmine Inmersion Technologies, Inc.",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "BMNR"
   },
   {
     "Cedears": "BMY",
     "Name": "Bristol-Myers Squibb Company",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "BMY"
   },
   {
     "Cedears": "BNG",
     "Name": "Bunge Limited",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "BNG"
   },
   {
     "Cedears": "BP",
     "Name": "BP PCL",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "BP"
   },
   {
     "Cedears": "BPA11",
     "Name": "Banco BTG Pactual S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "BPA11"
   },
   {
     "Cedears": "BRFS",
     "Name": "BRF S.A.",
     "Market": "NYSE",
-    "Ratio": "1:3"
+    "Ratio": "1:3",
+    "TickerOriginal": "BRFS"
   },
   {
     "Cedears": "BRKB",
     "Name": "Berkshire Hathaway Inc.",
     "Market": "NYSE",
-    "Ratio": "22"
+    "Ratio": "22",
+    "TickerOriginal": "BRKB"
   },
   {
     "Cedears": "BSBR",
     "Name": "Banco Santander (Brasil) S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "BSBR"
   },
   {
     "Cedears": "BSN",
     "Name": "Danone",
     "Market": "FRANKFURT",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "BSN"
   },
   {
     "Cedears": "BX",
     "Name": "Blackstone Inc.",
     "Market": "NYSE",
-    "Ratio": "30"
+    "Ratio": "30",
+    "TickerOriginal": "BX"
   },
   {
     "Cedears": "C",
     "Name": "Citigroup Inc",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "C"
   },
   {
     "Cedears": "CAAP",
     "Name": "Corporación America Airports S.A.",
     "Market": "NYSE",
-    "Ratio": "1:4"
+    "Ratio": "1:4",
+    "TickerOriginal": "CAAP"
   },
   {
     "Cedears": "CAH",
     "Name": "Cardinal Health Inc",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "CAH"
   },
   {
     "Cedears": "CAJ",
     "Name": "Canon Inc",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "CAJ"
   },
   {
     "Cedears": "CAR",
     "Name": "Avis Budget Group Inc.",
     "Market": "NASDAQ",
-    "Ratio": "26"
+    "Ratio": "26",
+    "TickerOriginal": "CAR"
   },
   {
     "Cedears": "CAT",
     "Name": "Caterpillar Inc",
     "Market": "NYSE",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "CAT"
   },
   {
     "Cedears": "CBRD",
     "Name": "Companhia Brasileira De Dis NPV ADR",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "CBRD"
   },
   {
     "Cedears": "CCJ",
     "Name": "Cameco Corporation",
     "Market": "NYSE",
-    "Ratio": "23"
+    "Ratio": "23",
+    "TickerOriginal": "CCJ"
   },
   {
     "Cedears": "CCL",
     "Name": "Carnival",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "CCL"
   },
   {
     "Cedears": "CDE",
     "Name": "Coeur Mining Inc.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "CDE"
   },
   {
     "Cedears": "CEG",
     "Name": "CONSTELLATION ENERGY CORPORATION",
     "Market": "NASDAQ GS",
-    "Ratio": "45"
+    "Ratio": "45",
+    "TickerOriginal": "CEG"
   },
   {
     "Cedears": "CIBR",
     "Name": "First Trust NASDAQ Cybersecurity",
     "Market": "NASDAQ GM",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "CIBR"
   },
   {
     "Cedears": "CL",
     "Name": "Colgate Palmolive Co",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "CL"
   },
   {
     "Cedears": "CLS",
     "Name": "CELESTICA INC",
     "Market": "NYSE",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "CLS"
   },
   {
     "Cedears": "COIN",
     "Name": "Coinbase Global Inc",
     "Market": "NASDAQ",
-    "Ratio": "27"
+    "Ratio": "27",
+    "TickerOriginal": "COIN"
   },
   {
     "Cedears": "COP",
     "Name": "ConocoPhillips",
     "Market": "NYSE",
-    "Ratio": "25"
+    "Ratio": "25",
+    "TickerOriginal": "COP"
   },
   {
     "Cedears": "COPX",
     "Name": "Global X Copper Miners ETF",
     "Market": "NYSE",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "COPX"
   },
   {
     "Cedears": "COST",
     "Name": "Costco Wholesale Corp",
     "Market": "NASDAQ",
-    "Ratio": "48"
+    "Ratio": "48",
+    "TickerOriginal": "COST"
   },
   {
     "Cedears": "CRM",
     "Name": "Salesforce Inc.",
     "Market": "NYSE",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "CRM"
   },
   {
     "Cedears": "CRWD",
     "Name": "CrowdStrike Holdings, Inc.",
     "Market": "NASDAQ GS",
-    "Ratio": "79"
+    "Ratio": "79",
+    "TickerOriginal": "CRWD"
   },
   {
     "Cedears": "CRWV",
     "Name": "CoreWeave Inc",
     "Market": "NASDAQ",
-    "Ratio": "27"
+    "Ratio": "27",
+    "TickerOriginal": "CRWV"
   },
   {
     "Cedears": "CS",
     "Name": "Credit Suisse Group",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "CS"
   },
   {
     "Cedears": "CSCO",
     "Name": "Cisco Systems Inc",
     "Market": "NASDAQ",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "CSCO"
   },
   {
     "Cedears": "CSNA3",
     "Name": "Companhia Siderúrgica Nacional S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "CSNA3"
   },
   {
     "Cedears": "CVS",
     "Name": "CVS Health",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "CVS"
   },
   {
     "Cedears": "CVX",
     "Name": "Chevron Corp.",
     "Market": "NYSE",
-    "Ratio": "16"
+    "Ratio": "16",
+    "TickerOriginal": "CVX"
   },
   {
     "Cedears": "CX",
     "Name": "Cemex S.A.B. de CV",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "CX"
   },
   {
     "Cedears": "DAL",
     "Name": "Delta Air Lines",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "DAL"
   },
   {
     "Cedears": "DD",
     "Name": "Dupont de Nemours Inc.",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "DD"
   },
   {
     "Cedears": "DE",
     "Name": "Deere & Co.",
     "Market": "NYSE",
-    "Ratio": "40"
+    "Ratio": "40",
+    "TickerOriginal": "DE"
   },
   {
     "Cedears": "DECK",
     "Name": "DECKERS OUTDOOR CORPORATION",
     "Market": "NYSE",
-    "Ratio": "25"
+    "Ratio": "25",
+    "TickerOriginal": "DECK"
   },
   {
     "Cedears": "DEO",
     "Name": "Diageo PLC",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "DEO"
   },
   {
     "Cedears": "DHR",
     "Name": "Danaher Corp",
     "Market": "NYSE",
-    "Ratio": "54"
+    "Ratio": "54",
+    "TickerOriginal": "DHR"
   },
   {
     "Cedears": "DIA",
     "Name": "SPDR DOW JONES INDUSTRIAL",
     "Market": "NYSE Arca",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "DIA"
   },
   {
     "Cedears": "DISN",
     "Name": "The Walt Disney Co.",
     "Market": "NYSE",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "DISN"
   },
   {
     "Cedears": "DOCU",
     "Name": "DocuSign Inc.",
     "Market": "NASDAQ",
-    "Ratio": "22"
+    "Ratio": "22",
+    "TickerOriginal": "DOCU"
   },
   {
     "Cedears": "DOW",
     "Name": "DOW Inc",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "DOW"
   },
   {
     "Cedears": "DTEA",
     "Name": "Deutsche Telekom Ag",
     "Market": "OTC US",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "DTEA"
   },
   {
     "Cedears": "E",
     "Name": "Eni Spa",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "E"
   },
   {
     "Cedears": "EA",
     "Name": "Electronic Arts Inc",
     "Market": "NASDAQ",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "EA"
   },
   {
     "Cedears": "EBAY",
     "Name": "Ebay Inc.",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "EBAY"
   },
   {
     "Cedears": "EBR",
     "Name": "Centrais Eléctricas Brasileiras S.A. - Eletrobras",
     "Market": "NYSE",
-    "Ratio": "1:4"
+    "Ratio": "1:4",
+    "TickerOriginal": "EBR"
   },
   {
     "Cedears": "ECL",
     "Name": "Ecolab Inc",
     "Market": "NYSE",
-    "Ratio": "56"
+    "Ratio": "56",
+    "TickerOriginal": "ECL"
   },
   {
     "Cedears": "EEM",
     "Name": "ISHARES MSCI EMERGING MARKET",
     "Market": "NYSE Arca",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "EEM"
   },
   {
     "Cedears": "EFA",
     "Name": "iShares MSCI EAFE ETF",
     "Market": "NYSE",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "EFA"
   },
   {
     "Cedears": "EFX",
     "Name": "Equifax Inc.",
     "Market": "NYSE",
-    "Ratio": "16"
+    "Ratio": "16",
+    "TickerOriginal": "EFX"
   },
   {
     "Cedears": "ELP",
     "Name": "Companhia Paranaense de Energía - COPEL",
     "Market": "NYSE",
-    "Ratio": "1:3"
+    "Ratio": "1:3",
+    "TickerOriginal": "ELP"
   },
   {
     "Cedears": "EOAN",
     "Name": "E.On Se",
     "Market": "FRANKFURT",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "EOAN"
   },
   {
     "Cedears": "EQNR",
     "Name": "Equinor Asa",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "EQNR"
   },
   {
     "Cedears": "ERIC",
     "Name": "Lm Ericsson Telephone Co.",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "ERIC"
   },
   {
     "Cedears": "ERJ",
     "Name": "Embraer-Empresa Brasileira de Aeronáutica S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "ERJ"
   },
   {
     "Cedears": "ESGU",
     "Name": "IShares ESG Aware MSCI USA ETF",
     "Market": "NASDAQ",
-    "Ratio": "30"
+    "Ratio": "30",
+    "TickerOriginal": "ESGU"
   },
   {
     "Cedears": "ETHA",
     "Name": "ISHARES ETHEREUM TR ETF",
     "Market": "NASDAQ",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "ETHA"
   },
   {
     "Cedears": "ETSY",
     "Name": "Etsy Inc.",
     "Market": "NASDAQ",
-    "Ratio": "16"
+    "Ratio": "16",
+    "TickerOriginal": "ETSY"
   },
   {
     "Cedears": "EWJ",
     "Name": "iShares MSCI JAPAN ETF",
     "Market": "NYSE Arca",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "EWJ"
   },
   {
     "Cedears": "EWY",
     "Name": "iShares MSCI South Korea ETF",
     "Market": "NYSE ARCA",
-    "Ratio": "50"
+    "Ratio": "50",
+    "TickerOriginal": "EWY"
   },
   {
     "Cedears": "EWZ",
     "Name": "ISHARES MSCI BRAZIL CAP",
     "Market": "NYSE Arca",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "EWZ"
   },
   {
     "Cedears": "F",
     "Name": "Ford Motor Company",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "F"
   },
   {
     "Cedears": "FCX",
     "Name": "Freeport Mcmoran Copper & Gold Inc.",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "FCX"
   },
   {
     "Cedears": "FDX",
     "Name": "Fedex Corp",
     "Market": "NYSE",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "FDX"
   },
   {
     "Cedears": "FISV",
     "Name": "Fiserv, Inc.",
     "Market": "NASDAQ GS",
-    "Ratio": "11"
+    "Ratio": "11",
+    "TickerOriginal": "FISV"
   },
   {
     "Cedears": "FMCC",
     "Name": "Freddie Mac (Federal Home Loan)",
     "Market": "OTC",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "FMCC"
   },
   {
     "Cedears": "FMX",
     "Name": "Fomento Economico Mexicano - Femsa",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "FMX"
   },
   {
     "Cedears": "FNMA",
     "Name": "Fed. Natl, Mortgage - Fannie Mae",
     "Market": "OTC",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "FNMA"
   },
   {
     "Cedears": "FSLR",
     "Name": "First Solar Inc.",
     "Market": "NASDAQ",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "FSLR"
   },
   {
     "Cedears": "FXI",
     "Name": "ISHARES CHINA LARGE-CAP ETF",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "FXI"
   },
   {
     "Cedears": "GDX",
     "Name": "Van Eck Gold Miners ETF/USA",
     "Market": "NYSE",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "GDX"
   },
   {
     "Cedears": "GE",
     "Name": "General Electric Co.",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "GE"
   },
   {
     "Cedears": "GFI",
     "Name": "Gold Fields Ltd.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "GFI"
   },
   {
     "Cedears": "GGB",
     "Name": "Gerdau S.A.",
     "Market": "NYSE",
-    "Ratio": "1:4"
+    "Ratio": "1:4",
+    "TickerOriginal": "GGB"
   },
   {
     "Cedears": "GILD",
     "Name": "Gilead Sciences, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "GILD"
   },
   {
     "Cedears": "GLD",
     "Name": "ETF SPDR GOLD TRUST",
     "Market": "NYSE",
-    "Ratio": "50"
+    "Ratio": "50",
+    "TickerOriginal": "GLD"
   },
   {
     "Cedears": "GLNG",
     "Name": "Golar LNG Ltd.",
     "Market": "NASDAQ GS",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "GLNG"
   },
   {
     "Cedears": "GLOB",
     "Name": "Globant S.A.",
     "Market": "NYSE",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "GLOB"
   },
   {
     "Cedears": "GLW",
     "Name": "Corning Inc.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "GLW"
   },
   {
     "Cedears": "GM",
     "Name": "General Motors Co",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "GM"
   },
   {
     "Cedears": "GOOGL",
     "Name": "Alphabet Inc.",
     "Market": "NASDAQ",
-    "Ratio": "58"
+    "Ratio": "58",
+    "TickerOriginal": "GOOGL"
   },
   {
     "Cedears": "GPRK",
     "Name": "Geopark Ltd.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "GPRK"
   },
   {
     "Cedears": "GRMN",
     "Name": "Garmin Ltd.",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "GRMN"
   },
   {
     "Cedears": "GS",
     "Name": "The Goldman Sachs Group, Inc",
     "Market": "NYSE",
-    "Ratio": "13"
+    "Ratio": "13",
+    "TickerOriginal": "GS"
   },
   {
     "Cedears": "GSK",
     "Name": "GSK Plc.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "GSK"
   },
   {
     "Cedears": "GT",
     "Name": "Goodyear Tire & Rubber co./the",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "GT"
   },
   {
     "Cedears": "HAL",
     "Name": "Halliburton Co.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "HAL"
   },
   {
     "Cedears": "HAPV3",
     "Name": "Hapvida Participacoes E Investimentos S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "HAPV3"
   },
   {
     "Cedears": "HD",
     "Name": "The Home Depot Inc.",
     "Market": "NYSE",
-    "Ratio": "32"
+    "Ratio": "32",
+    "TickerOriginal": "HD"
   },
   {
     "Cedears": "HDB",
     "Name": "Hdfc Bank Limited.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "HDB"
   },
   {
     "Cedears": "HHPD",
     "Name": "Hon Hai Precision Industry Co. Ltd.",
     "Market": "LONDON STOCK EXCHANGE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "HHPD"
   },
   {
     "Cedears": "HIMS",
     "Name": "Hims & Hers Health, Inc.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "HIMS"
   },
   {
     "Cedears": "HL",
     "Name": "Hecla Mining Co.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "HL"
   },
   {
     "Cedears": "HMC",
     "Name": "Honda Motor Co. Ltd",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "HMC"
   },
   {
     "Cedears": "HMY",
     "Name": "Harmony Gold Mining Company Ltd.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "HMY"
   },
   {
     "Cedears": "HNPIY",
     "Name": "Huaneng Power Intl",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "HNPIY"
   },
   {
     "Cedears": "HOG",
     "Name": "Harley-Davidson Inc.",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "HOG"
   },
   {
     "Cedears": "HON",
     "Name": "Honeywell International Inc.",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "HON"
   },
   {
     "Cedears": "HOOD",
     "Name": "Robinhood Markets Inc",
     "Market": "NASDAQ",
-    "Ratio": "29"
+    "Ratio": "29",
+    "TickerOriginal": "HOOD"
   },
   {
     "Cedears": "HPQ",
     "Name": "Hp Inc",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "HPQ"
   },
   {
     "Cedears": "HSBC",
     "Name": "Hsbc Holdings Plc",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "HSBC"
   },
   {
     "Cedears": "HSY",
     "Name": "The Hershey Company",
     "Market": "NYSE",
-    "Ratio": "21"
+    "Ratio": "21",
+    "TickerOriginal": "HSY"
   },
   {
     "Cedears": "HUT",
     "Name": "Hut 8 Mining Corp.",
     "Market": "NASDAQ GS",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "HUT"
   },
   {
     "Cedears": "HWM",
     "Name": "Howmet Aerospace Inc.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "HWM"
   },
   {
     "Cedears": "IBB",
     "Name": "iShares Nasdaq Biotechnology ETF",
     "Market": "NASDAQ",
-    "Ratio": "27"
+    "Ratio": "27",
+    "TickerOriginal": "IBB"
   },
   {
     "Cedears": "IBIT",
     "Name": "ISHARES BITCOIN TRUST",
     "Market": "NASDAQ",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "IBIT"
   },
   {
     "Cedears": "IBM",
     "Name": "International Business Machines",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "IBM"
   },
   {
     "Cedears": "IBN",
     "Name": "Icici Bank Ltd.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "IBN"
   },
   {
     "Cedears": "ICLN",
     "Name": "iShares Global Clean Energy ETF",
     "Market": "NASDAQ GM",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "ICLN"
   },
   {
     "Cedears": "IEMG",
     "Name": "iShares Core MSCI Emerging Markets ETF",
     "Market": "NYSE",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "IEMG"
   },
   {
     "Cedears": "IEUR",
     "Name": "iShares Core MSCI Europe ETF",
     "Market": "NYSE Arca",
-    "Ratio": "11"
+    "Ratio": "11",
+    "TickerOriginal": "IEUR"
   },
   {
     "Cedears": "IFF",
     "Name": "International Flavors & Fragrances Inc.",
     "Market": "NYSE",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "IFF"
   },
   {
     "Cedears": "IJH",
     "Name": "iShares CORE S&P MID-CAP ETF",
     "Market": "NYSE Arca",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "IJH"
   },
   {
     "Cedears": "ILF",
     "Name": "IShares Latin America 40 ETF",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "ILF"
   },
   {
     "Cedears": "INFY",
     "Name": "Infosys Limited",
     "Market": "NASDAQ",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "INFY"
   },
   {
     "Cedears": "ING",
     "Name": "Ing Groep Nv",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "ING"
   },
   {
     "Cedears": "INTC",
     "Name": "Intel Corporation",
     "Market": "NASDAQ",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "INTC"
   },
   {
     "Cedears": "IP",
     "Name": "International Paper Co.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "IP"
   },
   {
     "Cedears": "IREN",
     "Name": "Iren Ltd",
     "Market": "NASDAQ",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "IREN"
   },
   {
     "Cedears": "ISRG",
     "Name": "Intuitive Surgical inc",
     "Market": "NASDAQ",
-    "Ratio": "90"
+    "Ratio": "90",
+    "TickerOriginal": "ISRG"
   },
   {
     "Cedears": "ITA",
     "Name": "iShares U.S. Aerospace & Defense",
     "Market": "CBOE",
-    "Ratio": "50"
+    "Ratio": "50",
+    "TickerOriginal": "ITA"
   },
   {
     "Cedears": "ITUB",
     "Name": "Itaú Unibanco Holding S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "ITUB"
   },
   {
     "Cedears": "ITUB3",
     "Name": "Banco Itaú Unibanco S.A",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "ITUB3"
   },
   {
     "Cedears": "IVE",
     "Name": "iShares S&P 500 Value ETF",
     "Market": "NYSE Arca",
-    "Ratio": "40"
+    "Ratio": "40",
+    "TickerOriginal": "IVE"
   },
   {
     "Cedears": "IVV",
     "Name": "IShares Core S&P 500 ETF",
     "Market": "NYSE",
-    "Ratio": "692"
+    "Ratio": "692",
+    "TickerOriginal": "IVV"
   },
   {
     "Cedears": "IVW",
     "Name": "iShares S&P 500 Growth ETF",
     "Market": "NYSE Arca",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "IVW"
   },
   {
     "Cedears": "IWM",
     "Name": "ISHARES TRUST RUSSELL 2000",
     "Market": "NYSE Arca",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "IWM"
   },
   {
     "Cedears": "JCI",
     "Name": "Johnson Controls International",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "JCI"
   },
   {
     "Cedears": "JD",
     "Name": "Jd.Com, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "JD"
   },
   {
     "Cedears": "JMIA",
     "Name": "Adr Jumia Technologies Ag",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "JMIA"
   },
   {
     "Cedears": "JNJ",
     "Name": "Johnson & Johnson",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "JNJ"
   },
   {
     "Cedears": "JOYY",
     "Name": "JOYY Inc.",
     "Market": "NASDAQ",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "JOYY"
   },
   {
     "Cedears": "JPM",
     "Name": "J.P. Morgan & Chase Co.",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "JPM"
   },
   {
     "Cedears": "KB",
     "Name": "Kb Financial Group Inc.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "KB"
   },
   {
     "Cedears": "KEEL",
     "Name": "Bitfarms Ltd.",
     "Market": "NASDAQ GM",
-    "Ratio": "1:5"
+    "Ratio": "1:5",
+    "TickerOriginal": "KEEL"
   },
   {
     "Cedears": "KEP",
     "Name": "Korea Electric Power Corp.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "KEP"
   },
   {
     "Cedears": "KGC",
     "Name": "Kinross Gold Corp",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "KGC"
   },
   {
     "Cedears": "KMB",
     "Name": "Kimberly-Clark Corp.",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "KMB"
   },
   {
     "Cedears": "KO",
     "Name": "The Coca Cola Company",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "KO"
   },
   {
     "Cedears": "KOFM",
     "Name": "Coca-Cola Femsa, S.A.B. De C.V.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "KOFM"
   },
   {
     "Cedears": "LAC",
     "Name": "Lithium Americas Corp",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "LAC"
   },
   {
     "Cedears": "LAR",
     "Name": "Lithium Americas (Argentina) Corp",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "LAR"
   },
   {
     "Cedears": "LFC",
     "Name": "China Life Insurance",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "LFC"
   },
   {
     "Cedears": "LKOD",
     "Name": "Pjsc Lukoil",
     "Market": "LONDON STOCK EXCHANGE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "LKOD"
   },
   {
     "Cedears": "LLY",
     "Name": "Eli Lilly and Company",
     "Market": "NYSE",
-    "Ratio": "56"
+    "Ratio": "56",
+    "TickerOriginal": "LLY"
   },
   {
     "Cedears": "LMT",
     "Name": "Lockheed Martin Corporation",
     "Market": "NYSE",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "LMT"
   },
   {
     "Cedears": "LND",
     "Name": "Brasilagro - Co Brasileira de Propriedades Agrícolas",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "LND"
   },
   {
     "Cedears": "LRCX",
     "Name": "Lam Research Corp",
     "Market": "NASDAQ",
-    "Ratio": "56"
+    "Ratio": "56",
+    "TickerOriginal": "LRCX"
   },
   {
     "Cedears": "LREN3",
     "Name": "Lojas Renner S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "LREN3"
   },
   {
     "Cedears": "LVS",
     "Name": "Las Vegas Sands Corp",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "LVS"
   },
   {
     "Cedears": "LYG",
     "Name": "Lloyds Banking Group Plc",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "LYG"
   },
   {
     "Cedears": "MA",
     "Name": "Mastercard Inc.",
     "Market": "NYSE",
-    "Ratio": "33"
+    "Ratio": "33",
+    "TickerOriginal": "MA"
   },
   {
     "Cedears": "MBG",
     "Name": "Mercedes-Benz Group AG",
     "Market": "FRANKFURT",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "MBG"
   },
   {
     "Cedears": "MBT",
     "Name": "Mobile Telesystems",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "MBT"
   },
   {
     "Cedears": "MCD",
     "Name": "Mcdonald'S Corp.",
     "Market": "NYSE",
-    "Ratio": "24"
+    "Ratio": "24",
+    "TickerOriginal": "MCD"
   },
   {
     "Cedears": "MDLZ",
     "Name": "Mondelez",
     "Market": "NASDAQ",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "MDLZ"
   },
   {
     "Cedears": "MDT",
     "Name": "Medtronic Public Limited Company",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "MDT"
   },
   {
     "Cedears": "MELI",
     "Name": "Mercadolibre Inc.",
     "Market": "NASDAQ",
-    "Ratio": "120"
+    "Ratio": "120",
+    "TickerOriginal": "MELI"
   },
   {
     "Cedears": "META",
     "Name": "Meta Platforms Inc",
     "Market": "NASDAQ",
-    "Ratio": "24"
+    "Ratio": "24",
+    "TickerOriginal": "META"
   },
   {
     "Cedears": "MFG",
     "Name": "Mizuho Financial Group",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "MFG"
   },
   {
     "Cedears": "MGLU3",
     "Name": "Magazine Luiza S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "MGLU3"
   },
   {
     "Cedears": "MMC",
     "Name": "Marsh & Mclennan Companies Inc.",
     "Market": "NYSE",
-    "Ratio": "16"
+    "Ratio": "16",
+    "TickerOriginal": "MMC"
   },
   {
     "Cedears": "MMM",
     "Name": "3M Company",
     "Market": "NYSE",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "MMM"
   },
   {
     "Cedears": "MO",
     "Name": "Altria Group Inc.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "MO"
   },
   {
     "Cedears": "MOS",
     "Name": "The Mosaic Co",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "MOS"
   },
   {
     "Cedears": "MP",
     "Name": "MP Materials Corp.",
     "Market": "NYSE",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "MP"
   },
   {
     "Cedears": "MRK",
     "Name": "Merck & Co. Inc.",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "MRK"
   },
   {
     "Cedears": "MRNA",
     "Name": "Moderna Inc",
     "Market": "NASDAQ",
-    "Ratio": "19"
+    "Ratio": "19",
+    "TickerOriginal": "MRNA"
   },
   {
     "Cedears": "MRVL",
     "Name": "Marvell Technology Inc",
     "Market": "NASDAQ",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "MRVL"
   },
   {
     "Cedears": "MSFT",
     "Name": "Microsoft Corp.",
     "Market": "NASDAQ",
-    "Ratio": "30"
+    "Ratio": "30",
+    "TickerOriginal": "MSFT"
   },
   {
     "Cedears": "MSI",
     "Name": "Motorola Solutions, Inc.",
     "Market": "NYSE",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "MSI"
   },
   {
     "Cedears": "MSTR",
     "Name": "Microstrategy Inc Cl A New",
     "Market": "NASDAQ GS",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "MSTR"
   },
   {
     "Cedears": "MU",
     "Name": "Micron Technology Inc",
     "Market": "NASDAQ GS",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "MU"
   },
   {
     "Cedears": "MUFG",
     "Name": "Mitsubishi Ufj Financial Group",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "MUFG"
   },
   {
     "Cedears": "MUX",
     "Name": "McEwen Mining Inc",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "MUX"
   },
   {
     "Cedears": "NATU3",
     "Name": "Natura Cosméticos S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "NATU3"
   },
   {
     "Cedears": "NBIS",
     "Name": "Nebius Group N.V.",
     "Market": "NASDAQ GS",
-    "Ratio": "27"
+    "Ratio": "27",
+    "TickerOriginal": "NBIS"
   },
   {
     "Cedears": "NEC1",
     "Name": "Nec Corporation",
     "Market": "FRANKFURT",
-    "Ratio": "1:3"
+    "Ratio": "1:3",
+    "TickerOriginal": "NEC1"
   },
   {
     "Cedears": "NEE",
     "Name": "NextEra Energy, Inc.",
     "Market": "NYSE",
-    "Ratio": "19"
+    "Ratio": "19",
+    "TickerOriginal": "NEE"
   },
   {
     "Cedears": "NEM",
     "Name": "Newmont Corporation",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "NEM"
   },
   {
     "Cedears": "NFLX",
     "Name": "Netflix, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "48"
+    "Ratio": "48",
+    "TickerOriginal": "NFLX"
   },
   {
     "Cedears": "NG",
     "Name": "Novagold Resources INC.",
     "Market": "NYSE",
-    "Ratio": "1:4"
+    "Ratio": "1:4",
+    "TickerOriginal": "NG"
   },
   {
     "Cedears": "NGG",
     "Name": "National Grid Plc",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "NGG"
   },
   {
     "Cedears": "NIO",
     "Name": "NIO Inc.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "NIO"
   },
   {
     "Cedears": "NKE",
     "Name": "Nike Inc.",
     "Market": "NYSE",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "NKE"
   },
   {
     "Cedears": "NLM",
     "Name": "Novolipetsk Steel PJSC",
     "Market": "LONDON STOCK EXCHANGE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "NLM"
   },
   {
     "Cedears": "NMR",
     "Name": "Nomura Holdings, Inc",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "NMR"
   },
   {
     "Cedears": "NOKA",
     "Name": "Nokia Corporation",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "NOKA"
   },
   {
     "Cedears": "NOW",
     "Name": "SERVICENOW INC",
     "Market": "NYSE",
-    "Ratio": "172"
+    "Ratio": "172",
+    "TickerOriginal": "NOW"
   },
   {
     "Cedears": "NSAN",
     "Name": "Nissan Motor Co., Ltd",
     "Market": "OTC US",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "NSAN"
   },
   {
     "Cedears": "NTES",
     "Name": "Netease, Inc",
     "Market": "NASDAQ",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "NTES"
   },
   {
     "Cedears": "NUE",
     "Name": "Nucor Corp",
     "Market": "NYSE",
-    "Ratio": "16"
+    "Ratio": "16",
+    "TickerOriginal": "NUE"
   },
   {
     "Cedears": "NVDA",
     "Name": "Nvidia Corporation",
     "Market": "NASDAQ",
-    "Ratio": "24"
+    "Ratio": "24",
+    "TickerOriginal": "NVDA"
   },
   {
     "Cedears": "NVO",
     "Name": "Novo Nordisk A/S",
     "Market": "NYSE",
-    "Ratio": "7"
+    "Ratio": "7",
+    "TickerOriginal": "NVO"
   },
   {
     "Cedears": "NVS",
     "Name": "Novartis Ag",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "NVS"
   },
   {
     "Cedears": "NXE",
     "Name": "Nexgen Energy LTD",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "NXE"
   },
   {
     "Cedears": "O",
     "Name": "Realty Income Corp.",
     "Market": "NYSE",
-    "Ratio": "13"
+    "Ratio": "13",
+    "TickerOriginal": "O"
   },
   {
     "Cedears": "OGZD",
     "Name": "Pjsc Gazprom",
     "Market": "LONDON STOCK EXCHANGE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "OGZD"
   },
   {
     "Cedears": "OKLO",
     "Name": "Oklo Inc",
     "Market": "NYSE",
-    "Ratio": "28"
+    "Ratio": "28",
+    "TickerOriginal": "OKLO"
   },
   {
     "Cedears": "ONDS",
     "Name": "Ondas Holdings Inc.",
     "Market": "NASDAQ CM",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "ONDS"
   },
   {
     "Cedears": "ORAN",
     "Name": "Orange S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "ORAN"
   },
   {
     "Cedears": "ORCL",
     "Name": "Oracle Corporation",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "ORCL"
   },
   {
     "Cedears": "ORLY",
     "Name": "O'reilly Automotive Inc",
     "Market": "NASDAQ",
-    "Ratio": "222"
+    "Ratio": "222",
+    "TickerOriginal": "ORLY"
   },
   {
     "Cedears": "OXY",
     "Name": "Occidental Petroleum Corp.",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "OXY"
   },
   {
     "Cedears": "PAAS",
     "Name": "Pan American Silver Corp.",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "PAAS"
   },
   {
     "Cedears": "PAC",
     "Name": "Grupo Aeroportuario del Pacifico, S.A.B. de C.V.",
     "Market": "NYSE",
-    "Ratio": "16"
+    "Ratio": "16",
+    "TickerOriginal": "PAC"
   },
   {
     "Cedears": "PAGS",
     "Name": "Pagseguro Digital Ltd",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "PAGS"
   },
   {
     "Cedears": "PANW",
     "Name": "Palo Alto Networks Inc",
     "Market": "NASDAQ GS",
-    "Ratio": "50"
+    "Ratio": "50",
+    "TickerOriginal": "PANW"
   },
   {
     "Cedears": "PATH",
     "Name": "UIPATH INC",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "PATH"
   },
   {
     "Cedears": "PBI",
     "Name": "Pitney Bowes Inc",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "PBI"
   },
   {
     "Cedears": "PBR",
     "Name": "Petrobras (ADR)",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "PBR"
   },
   {
     "Cedears": "PCAR",
     "Name": "Paccar Inc.",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "PCAR"
   },
   {
     "Cedears": "PCRF",
     "Name": "Panasonic Corporation",
     "Market": "OTC US",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "PCRF"
   },
   {
     "Cedears": "PDD",
     "Name": "PDD HOLDINGS INC",
     "Market": "NASDAQ GS",
-    "Ratio": "25"
+    "Ratio": "25",
+    "TickerOriginal": "PDD"
   },
   {
     "Cedears": "PEP",
     "Name": "Pepsico Inc",
     "Market": "NASDAQ",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "PEP"
   },
   {
     "Cedears": "PETR3",
     "Name": "Petrobras - Petróleo Brasileiro S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "PETR3"
   },
   {
     "Cedears": "PFE",
     "Name": "Pfizer Inc.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "PFE"
   },
   {
     "Cedears": "PG",
     "Name": "Procter & Gamble",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "PG"
   },
   {
     "Cedears": "PHG",
     "Name": "Koninklijke Philips N.V.",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "PHG"
   },
   {
     "Cedears": "PINS",
     "Name": "Pinterest",
     "Market": "NYSE",
-    "Ratio": "7"
+    "Ratio": "7",
+    "TickerOriginal": "PINS"
   },
   {
     "Cedears": "PKS",
     "Name": "Posco Holdings Inc.",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "PKS"
   },
   {
     "Cedears": "PLTR",
     "Name": "Palantir Technologies Inc",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "PLTR"
   },
   {
     "Cedears": "PM",
     "Name": "Philip Morris International",
     "Market": "NYSE",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "PM"
   },
   {
     "Cedears": "PRIO3",
     "Name": "Petro Rio S.A.",
     "Market": "B3",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "PRIO3"
   },
   {
     "Cedears": "PSO",
     "Name": "Pearson Plc",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "PSO"
   },
   {
     "Cedears": "PSQ",
     "Name": "PROSHARES SHORT QQQ",
     "Market": "NYSE Arca",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "PSQ"
   },
   {
     "Cedears": "PSX",
     "Name": "Phillips 66",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "PSX"
   },
   {
     "Cedears": "PTR",
     "Name": "Petrochina Co Ltd",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "PTR"
   },
   {
     "Cedears": "PYPL",
     "Name": "Paypal Holdings, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "PYPL"
   },
   {
     "Cedears": "QCOM",
     "Name": "Qualcomm Inc.",
     "Market": "NASDAQ",
-    "Ratio": "11"
+    "Ratio": "11",
+    "TickerOriginal": "QCOM"
   },
   {
     "Cedears": "QQQ",
     "Name": "INVESCO QQQ TRUST",
     "Market": "NASDAQ",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "QQQ"
   },
   {
     "Cedears": "RACE",
     "Name": "Ferrari",
     "Market": "NYSE",
-    "Ratio": "83"
+    "Ratio": "83",
+    "TickerOriginal": "RACE"
   },
   {
     "Cedears": "RBLX",
     "Name": "Roblox Corp.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "RBLX"
   },
   {
     "Cedears": "RCTB4",
     "Name": "Telebras PN",
     "Market": "BOVESPA",
-    "Ratio": "1:1000"
+    "Ratio": "1:1000",
+    "TickerOriginal": "RCTB4"
   },
   {
     "Cedears": "RGTI",
     "Name": "RIGETTI COMPUTING INC",
     "Market": "NASDAQ CM",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "RGTI"
   },
   {
     "Cedears": "RENT3",
     "Name": "Localiza Rent A Car S.A.",
     "Market": "B3",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "RENT3"
   },
   {
     "Cedears": "RIO",
     "Name": "Rio Tinto Plc",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "RIO"
   },
   {
     "Cedears": "RIOT",
     "Name": "Riot Platforms",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "RIOT"
   },
   {
     "Cedears": "RKLB",
     "Name": "Rocket Lab Corp",
     "Market": "NASDAQ",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "RKLB"
   },
   {
     "Cedears": "ROKU",
     "Name": "Roku",
     "Market": "NASDAQ",
-    "Ratio": "13"
+    "Ratio": "13",
+    "TickerOriginal": "ROKU"
   },
   {
     "Cedears": "ROST",
     "Name": "Ross Stores, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "ROST"
   },
   {
     "Cedears": "RSP",
     "Name": "Invesco S&P 500 Equal Weight ETF",
     "Market": "NYSE ARCA",
-    "Ratio": "30"
+    "Ratio": "30",
+    "TickerOriginal": "RSP"
   },
   {
     "Cedears": "RTX",
     "Name": "Raytheon Technologies Corp",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "RTX"
   },
   {
     "Cedears": "SAN",
     "Name": "Banco Santander S.A",
     "Market": "NYSE",
-    "Ratio": "1:4"
+    "Ratio": "1:4",
+    "TickerOriginal": "SAN"
   },
   {
     "Cedears": "SAP",
     "Name": "Sap Se",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "SAP"
   },
   {
     "Cedears": "SATL",
     "Name": "Satellogic Inc.",
     "Market": "NASDAQ GS",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "SATL"
   },
   {
     "Cedears": "SBS",
     "Name": "Companhia de Saneamento Básico do Estado de São Paulo–Sabesp",
     "Market": "NYSE",
-    "Ratio": "1:2"
+    "Ratio": "1:2",
+    "TickerOriginal": "SBS"
   },
   {
     "Cedears": "SBSP3",
     "Name": "Cia Saneamento Básico de SP",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "SBSP3"
   },
   {
     "Cedears": "SBUX",
     "Name": "Starbucks Corporation",
     "Market": "NASDAQ",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "SBUX"
   },
   {
     "Cedears": "SCCO",
     "Name": "Southern Copper Corp",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "SCCO"
   },
   {
     "Cedears": "SCHW",
     "Name": "Charles Schwab",
     "Market": "NYSE",
-    "Ratio": "13"
+    "Ratio": "13",
+    "TickerOriginal": "SCHW"
   },
   {
     "Cedears": "SDA",
     "Name": "SunCar Technology Group Inc",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "SDA"
   },
   {
     "Cedears": "SE",
     "Name": "Sea Ltd.",
     "Market": "NYSE",
-    "Ratio": "32"
+    "Ratio": "32",
+    "TickerOriginal": "SE"
   },
   {
     "Cedears": "SH",
     "Name": "PROSHARES SHORT S&P500",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "SH"
   },
   {
     "Cedears": "SHEL",
     "Name": "Royal Dutch Shell Plc",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "SHEL"
   },
   {
     "Cedears": "SHOP",
     "Name": "Shopify Inc.",
     "Market": "NYSE",
-    "Ratio": "107"
+    "Ratio": "107",
+    "TickerOriginal": "SHOP"
   },
   {
     "Cedears": "SHPW",
     "Name": "Shapeways Holdings Inc",
     "Market": "NYSE",
-    "Ratio": "1:2"
+    "Ratio": "1:2",
+    "TickerOriginal": "SHPW"
   },
   {
     "Cedears": "SI",
     "Name": "Silvergate Bancorp",
     "Market": "NYSE",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "SI"
   },
   {
     "Cedears": "SID",
     "Name": "Companhia Siderúrgica Nacional",
     "Market": "NYSE",
-    "Ratio": "1:8"
+    "Ratio": "1:8",
+    "TickerOriginal": "SID"
   },
   {
     "Cedears": "SIEGY",
     "Name": "Siemens Ag Adr",
     "Market": "OTC",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "SIEGY"
   },
   {
     "Cedears": "SLB",
     "Name": "Schlumberger Ltd",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "SLB"
   },
   {
     "Cedears": "SLV",
     "Name": "iShares SILVER TRUST",
     "Market": "NYSE Arca",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "SLV"
   },
   {
     "Cedears": "SMH",
     "Name": "VAN ECK SEMICONDUCTOR ETF",
     "Market": "NASDAQ",
-    "Ratio": "50"
+    "Ratio": "50",
+    "TickerOriginal": "SMH"
   },
   {
     "Cedears": "SMSN",
     "Name": "Samsung Electronics Co. Ltd.",
     "Market": "LONDON STOCK EXCHANGE",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "SMSN"
   },
   {
     "Cedears": "SNA",
     "Name": "Snap-On Inc",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "SNA"
   },
   {
     "Cedears": "SNAP",
     "Name": "Snap Inc.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "SNAP"
   },
   {
     "Cedears": "SNDK",
     "Name": "Sandisk Corporation",
     "Market": "NASDAQ GS",
-    "Ratio": "170"
+    "Ratio": "170",
+    "TickerOriginal": "SNDK"
   },
   {
     "Cedears": "SNOW",
     "Name": "Snowflake Inc.",
     "Market": "NYSE",
-    "Ratio": "30"
+    "Ratio": "30",
+    "TickerOriginal": "SNOW"
   },
   {
     "Cedears": "SNP",
     "Name": "China Petroleum & Chem",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "SNP"
   },
   {
     "Cedears": "SONY",
     "Name": "Sony Group Corporation",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "SONY"
   },
   {
     "Cedears": "SPCE",
     "Name": "Virgin Galactic",
     "Market": "NYSE",
-    "Ratio": "1:2"
+    "Ratio": "1:2",
+    "TickerOriginal": "SPCE"
   },
   {
     "Cedears": "SPCX",
     "Name": "Space Exploration Technologies Corp.",
     "Market": "NASDAQ GS",
-    "Ratio": "50"
+    "Ratio": "50",
+    "TickerOriginal": "SPCX"
   },
   {
     "Cedears": "SPGI",
     "Name": "S&P Global Inc",
     "Market": "NYSE",
-    "Ratio": "45"
+    "Ratio": "45",
+    "TickerOriginal": "SPGI"
   },
   {
     "Cedears": "SPHQ",
     "Name": "Invesco S&P 500 Quality ETF",
     "Market": "NYSE ARCA",
-    "Ratio": "14"
+    "Ratio": "14",
+    "TickerOriginal": "SPHQ"
   },
   {
     "Cedears": "SPOT",
     "Name": "Spotify Technology S.A.",
     "Market": "NYSE",
-    "Ratio": "28"
+    "Ratio": "28",
+    "TickerOriginal": "SPOT"
   },
   {
     "Cedears": "SPXL",
     "Name": "DIREXION DAILY S&P 500 BULL 3X",
     "Market": "NYSE Arca",
-    "Ratio": "25"
+    "Ratio": "25",
+    "TickerOriginal": "SPXL"
   },
   {
     "Cedears": "SPY",
     "Name": "SPDR S&P 500",
     "Market": "NYSE Arca",
-    "Ratio": "60"
+    "Ratio": "60",
+    "TickerOriginal": "SPY"
   },
   {
     "Cedears": "STLA",
     "Name": "Stellantis",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "STLA"
   },
   {
     "Cedears": "STNE",
     "Name": "StoneCo Ltd",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "STNE"
   },
   {
     "Cedears": "SUZ",
     "Name": "Suzano Papel E Celulose S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "SUZ"
   },
   {
     "Cedears": "SUZB3",
     "Name": "Suzano S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "SUZB3"
   },
   {
     "Cedears": "SWKS",
     "Name": "Skyworks Solutions",
     "Market": "NASDAQ",
-    "Ratio": "21"
+    "Ratio": "21",
+    "TickerOriginal": "SWKS"
   },
   {
     "Cedears": "SYY",
     "Name": "Sysco Corp.",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "SYY"
   },
   {
     "Cedears": "T",
     "Name": "At &T Inc.",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "T"
   },
   {
     "Cedears": "TCOM",
     "Name": "TRIP.COM Group Ltd.",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "TCOM"
   },
   {
     "Cedears": "TEAM",
     "Name": "ATLASSIAN CORPORATION",
     "Market": "NASDAQ GS",
-    "Ratio": "47"
+    "Ratio": "47",
+    "TickerOriginal": "TEAM"
   },
   {
     "Cedears": "TEFO",
     "Name": "Telefonica S.A.",
     "Market": "NYSE",
-    "Ratio": "8"
+    "Ratio": "8",
+    "TickerOriginal": "TEFO"
   },
   {
     "Cedears": "TEM",
     "Name": "TEMPUS AI INC",
     "Market": "NASDAQ GS",
-    "Ratio": "12"
+    "Ratio": "12",
+    "TickerOriginal": "TEM"
   },
   {
     "Cedears": "TEN",
     "Name": "Tenaris",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "TEN"
   },
   {
     "Cedears": "TGT",
     "Name": "Target Corporation",
     "Market": "NYSE",
-    "Ratio": "24"
+    "Ratio": "24",
+    "TickerOriginal": "TGT"
   },
   {
     "Cedears": "TIIAY",
     "Name": "Telecom Italia S.P.A. Ordinary Shares",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "TIIAY"
   },
   {
     "Cedears": "TIMB",
     "Name": "Tim Participações S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "TIMB"
   },
   {
     "Cedears": "TIMS3",
     "Name": "TIM S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "TIMS3"
   },
   {
     "Cedears": "TJX",
     "Name": "TJX Companies Inc/The",
     "Market": "NYSE",
-    "Ratio": "22"
+    "Ratio": "22",
+    "TickerOriginal": "TJX"
   },
   {
     "Cedears": "TM",
     "Name": "Toyota Motor Corporation",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "TM"
   },
   {
     "Cedears": "TMO",
     "Name": "Thermo Fisher Scientific Inc.",
     "Market": "NYSE",
-    "Ratio": "22"
+    "Ratio": "22",
+    "TickerOriginal": "TMO"
   },
   {
     "Cedears": "TMUS",
     "Name": "T-mobile",
     "Market": "NASDAQ",
-    "Ratio": "33"
+    "Ratio": "33",
+    "TickerOriginal": "TMUS"
   },
   {
     "Cedears": "TQQQ",
     "Name": "ProShares UltraPro QQQ",
     "Market": "NASDAQ",
-    "Ratio": "25"
+    "Ratio": "25",
+    "TickerOriginal": "TQQQ"
   },
   {
     "Cedears": "TRIP",
     "Name": "Tripadvisor, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "TRIP"
   },
   {
     "Cedears": "TRVV",
     "Name": "The Travelers Cos. Inc.",
     "Market": "NYSE",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "TRVV"
   },
   {
     "Cedears": "TSLA",
     "Name": "Tesla, Inc.",
     "Market": "NASDAQ",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "TSLA"
   },
   {
     "Cedears": "TSM",
     "Name": "Taiwan Semiconductor Manufacturing",
     "Market": "NYSE",
-    "Ratio": "9"
+    "Ratio": "9",
+    "TickerOriginal": "TSM"
   },
   {
     "Cedears": "TTE",
     "Name": "TotalEnergies SE",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "TTE"
   },
   {
     "Cedears": "TTM",
     "Name": "Tata Motors Ltd",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "TTM"
   },
   {
     "Cedears": "TV",
     "Name": "Grupo Televisa S.A.",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "TV"
   },
   {
     "Cedears": "TWLO",
     "Name": "Twilio Inc",
     "Market": "NYSE",
-    "Ratio": "36"
+    "Ratio": "36",
+    "TickerOriginal": "TWLO"
   },
   {
     "Cedears": "TWTR",
     "Name": "Twitter, Inc.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "TWTR"
   },
   {
     "Cedears": "TXN",
     "Name": "Texas Instruments Inc",
     "Market": "NASDAQ",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "TXN"
   },
   {
     "Cedears": "TXR",
     "Name": "Ternium S.A.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "TXR"
   },
   {
     "Cedears": "UAL",
     "Name": "United Airlines Holdings Inc.",
     "Market": "NASDAQ GS",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "UAL"
   },
   {
     "Cedears": "UBER",
     "Name": "Uber Technologies Inc.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "UBER"
   },
   {
     "Cedears": "UGP",
     "Name": "Ultrapar Participações S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "UGP"
   },
   {
     "Cedears": "UL",
     "Name": "Unilever PLC - Sponsored",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "UL"
   },
   {
     "Cedears": "UN",
     "Name": "NU Holdings Ltd/Cayman Islands",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "UN"
   },
   {
     "Cedears": "UNH",
     "Name": "UnitedHealth Group Inc.",
     "Market": "NYSE",
-    "Ratio": "33"
+    "Ratio": "33",
+    "TickerOriginal": "UNH"
   },
   {
     "Cedears": "UNP",
     "Name": "Union Pacific Corp.",
     "Market": "NYSE",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "UNP"
   },
   {
     "Cedears": "UPST",
     "Name": "Upstart Hldgs Inc",
     "Market": "NASDAQ GS",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "UPST"
   },
   {
     "Cedears": "URA",
     "Name": "Global X Uranium ETF",
     "Market": "NYSE Arca",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "URA"
   },
   {
     "Cedears": "URBN",
     "Name": "Urban Outfitters INC.",
     "Market": "NASDAQ",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "URBN"
   },
   {
     "Cedears": "USB",
     "Name": "U.S. Bancorp",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "USB"
   },
   {
     "Cedears": "USO",
     "Name": "United States Oil Fund",
     "Market": "NYSE",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "USO"
   },
   {
     "Cedears": "V",
     "Name": "Visa Inc",
     "Market": "NYSE",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "V"
   },
   {
     "Cedears": "VALE",
     "Name": "Vale S.A.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "VALE"
   },
   {
     "Cedears": "VALE3",
     "Name": "Vale S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "VALE3"
   },
   {
     "Cedears": "VEA",
     "Name": "Vanguard FTSE Developed Markets ETF",
     "Market": "NYSE Arca",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "VEA"
   },
   {
     "Cedears": "VIG",
     "Name": "VANGUARD DIVIDEND APPRECIATION",
     "Market": "NYSE Arca",
-    "Ratio": "39"
+    "Ratio": "39",
+    "TickerOriginal": "VIG"
   },
   {
     "Cedears": "VIST",
     "Name": "Vista Energy S.A.B. de C.V.",
     "Market": "NYSE",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "VIST"
   },
   {
     "Cedears": "VIV",
     "Name": "Telefônica Brasil S.A.",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "VIV"
   },
   {
     "Cedears": "VIVT3",
     "Name": "Telefônica Brasil S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "VIVT3"
   },
   {
     "Cedears": "VOD",
     "Name": "Vodafone Group Plc",
     "Market": "NASDAQ",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "VOD"
   },
   {
     "Cedears": "VRSN",
     "Name": "Verisign, Inc.",
     "Market": "-",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "VRSN"
   },
   {
     "Cedears": "VRTX",
     "Name": "VERTEX PHARMACEUTICALS INC",
     "Market": "NYSE",
-    "Ratio": "101"
+    "Ratio": "101",
+    "TickerOriginal": "VRTX"
   },
   {
     "Cedears": "VST",
     "Name": "VISTRA CORPORATION",
     "Market": "NYSE",
-    "Ratio": "26"
+    "Ratio": "26",
+    "TickerOriginal": "VST"
   },
   {
     "Cedears": "VXX",
     "Name": "iPath Series B S&P 500 VIX",
     "Market": "CBOE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "VXX"
   },
   {
     "Cedears": "VZ",
     "Name": "Verizon Communications Inc.",
     "Market": "NYSE",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "VZ"
   },
   {
     "Cedears": "WBA",
     "Name": "Walgreens Boots Alliance Inc.",
     "Market": "NASDAQ",
-    "Ratio": "3"
+    "Ratio": "3",
+    "TickerOriginal": "WBA"
   },
   {
     "Cedears": "WBO",
     "Name": "Weibo Corporation",
     "Market": "NASDAQ",
-    "Ratio": "6"
+    "Ratio": "6",
+    "TickerOriginal": "WBO"
   },
   {
     "Cedears": "WEGE3",
     "Name": "Weg S.A.",
     "Market": "B3",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "WEGE3"
   },
   {
     "Cedears": "WFC",
     "Name": "Wells Fargo & Co.",
     "Market": "NYSE",
-    "Ratio": "5"
+    "Ratio": "5",
+    "TickerOriginal": "WFC"
   },
   {
     "Cedears": "WMT",
     "Name": "Walmart Inc.",
     "Market": "NYSE",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "WMT"
   },
   {
     "Cedears": "XLB",
     "Name": "The Materials Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "18"
+    "Ratio": "18",
+    "TickerOriginal": "XLB"
   },
   {
     "Cedears": "XLC",
     "Name": "The Communication Services Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "19"
+    "Ratio": "19",
+    "TickerOriginal": "XLC"
   },
   {
     "Cedears": "XLE",
     "Name": "ENERGY SELECT SECTOR SPDR FUND",
     "Market": "NYSE Arca",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "XLE"
   },
   {
     "Cedears": "XLF",
     "Name": "FINANCIAL SELECT SECTOR SPDR FUND",
     "Market": "NYSE Arca",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "XLF"
   },
   {
     "Cedears": "XLI",
     "Name": "The Industrial Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "28"
+    "Ratio": "28",
+    "TickerOriginal": "XLI"
   },
   {
     "Cedears": "XLK",
     "Name": "The Technology Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "46"
+    "Ratio": "46",
+    "TickerOriginal": "XLK"
   },
   {
     "Cedears": "XLP",
     "Name": "The Consumer Staples Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "16"
+    "Ratio": "16",
+    "TickerOriginal": "XLP"
   },
   {
     "Cedears": "XLRE",
     "Name": "The Real Estate Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "9"
+    "Ratio": "9",
+    "TickerOriginal": "XLRE"
   },
   {
     "Cedears": "XLU",
     "Name": "Utilities Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "15"
+    "Ratio": "15",
+    "TickerOriginal": "XLU"
   },
   {
     "Cedears": "XLV",
     "Name": "The Health Care Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "29"
+    "Ratio": "29",
+    "TickerOriginal": "XLV"
   },
   {
     "Cedears": "XME",
     "Name": "State Street SPDR S&P Metals & Mining ETF",
     "Market": "NYSE ARCA",
-    "Ratio": "30"
+    "Ratio": "30",
+    "TickerOriginal": "XME"
   },
   {
     "Cedears": "XLY",
     "Name": "The Consumer Discretionary Select Sector SPDR Fund",
     "Market": "NYSE Arca",
-    "Ratio": "43"
+    "Ratio": "43",
+    "TickerOriginal": "XLY"
   },
   {
     "Cedears": "XOM",
     "Name": "Exxon Mobil Corporation",
     "Market": "NYSE",
-    "Ratio": "10"
+    "Ratio": "10",
+    "TickerOriginal": "XOM"
   },
   {
     "Cedears": "XP",
     "Name": "XP Inc",
     "Market": "NASDAQ",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "XP"
   },
   {
     "Cedears": "XPEV",
     "Name": "XPENG INC",
     "Market": "New York",
-    "Ratio": "4"
+    "Ratio": "4",
+    "TickerOriginal": "XPEV"
   },
   {
     "Cedears": "XROX",
     "Name": "Xerox Holding Corporation",
     "Market": "NYSE",
-    "Ratio": "1"
+    "Ratio": "1",
+    "TickerOriginal": "XROX"
   },
   {
     "Cedears": "XYZ",
     "Name": "Square Inc.",
     "Market": "NYSE",
-    "Ratio": "20"
+    "Ratio": "20",
+    "TickerOriginal": "XYZ"
   },
   {
     "Cedears": "YELP",
     "Name": "Yelp Inc.",
     "Market": "NYSE",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "YELP"
   },
   {
     "Cedears": "YZCA",
     "Name": "Yanzhou Coal Mining Co. Ltd.",
     "Market": "OTC US",
-    "Ratio": "2"
+    "Ratio": "2",
+    "TickerOriginal": "YZCA"
   },
   {
     "Cedears": "ZM",
     "Name": "Zoom Video Communications Inc.",
     "Market": "NASDAQ",
-    "Ratio": "47"
+    "Ratio": "47",
+    "TickerOriginal": "ZM"
   }
 ]

--- a/doc/CEDEAR.md
+++ b/doc/CEDEAR.md
@@ -22,6 +22,7 @@ Cada entrada del listado contiene:
 - **Name**: Nombre completo de la empresa
 - **Market**: Mercado donde cotiza el instrumento subyacente (ej. NYSE, NASDAQ, B3)
 - **Ratio**: Ratio de conversión entre el CEDEAR y la acción subyacente (string)
+- **TickerOriginal**: Ticker del subyacente en su mercado de origen (puede diferir del ticker BYMA; ej. `ADGO` → `AGRO`)
 
 ### Formatos de `ratio`
 
@@ -60,6 +61,7 @@ En cualquier celda de la hoja, escribe:
 - "name" - Nombre completo de la empresa
 - "ratio" - Ratio de conversión entre el CEDEAR y la acción subyacente
 - "market" - Mercado donde cotiza el subyacente (ej. NYSE, NASDAQ, B3)
+- "ticker_original" - Ticker del subyacente en su mercado de origen (ej. ADGO → AGRO)
 
 ## Ejemplos
 
@@ -71,6 +73,7 @@ En cualquier celda de la hoja, escribe:
 | `=CEDEAR("TSLA"; "name")` | Nombre completo de la empresa Tesla |
 | `=CEDEAR("AMZN"; "ratio")` | Ratio de conversión del CEDEAR de Amazon |
 | `=CEDEAR("AAPL"; "market")` | Mercado donde cotiza Apple (NASDAQ) |
+| `=CEDEAR("ADGO"; "ticker_original")` | Ticker del subyacente Adecoagro (AGRO) |
 
 ## Función CedearLista
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Publicada en Pages (sin backend):
 
 | Endpoint | Descripción |
 |----------|-------------|
-| [`/api/cedears.json`](https://ferminrp.github.io/google-sheets-argento/api/cedears.json) | Listado de CEDEARs con `Cedears`, `Name`, `Market`, `Ratio` + metadata |
+| [`/api/cedears.json`](https://ferminrp.github.io/google-sheets-argento/api/cedears.json) | Listado de CEDEARs con `Cedears`, `Name`, `Market`, `Ratio`, `TickerOriginal` + metadata |
 
 Fuente canónica: [`data/cedears.json`](../data/cedears.json) (array plano).  
 `npm run build` regenera `docs/api/cedears.json` con un envelope para agentes/scripts.  

--- a/docs/api/cedears.json
+++ b/docs/api/cedears.json
@@ -10,7 +10,8 @@
     "Cedears": "Ticker del CEDEAR en BYMA",
     "Name": "Nombre de la empresa / instrumento subyacente",
     "Market": "Mercado donde cotiza el subyacente (ej. NYSE, NASDAQ, B3)",
-    "Ratio": "String de conversión. Formato 'N' (ej. \"20\") = N CEDEARs por 1 acción; formato 'A:B' (ej. \"1:3\") = razón A:B. No se normaliza."
+    "Ratio": "String de conversión. Formato 'N' (ej. \"20\") = N CEDEARs por 1 acción; formato 'A:B' (ej. \"1:3\") = razón A:B. No se normaliza.",
+    "TickerOriginal": "Ticker del instrumento subyacente en su mercado de origen (puede diferir del ticker BYMA)"
   },
   "count": 428,
   "items": [
@@ -18,2569 +19,2997 @@
       "Cedears": "AABA",
       "Name": "Altaba Inc.",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "AABA"
     },
     {
       "Cedears": "AAL",
       "Name": "American Airlines Group Inc",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "AAL"
     },
     {
       "Cedears": "AAP",
       "Name": "Advanced Auto Parts Inc",
       "Market": "NYSE",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "AAP"
     },
     {
       "Cedears": "AAPL",
       "Name": "Apple Inc.",
       "Market": "NASDAQ",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "AAPL"
     },
     {
       "Cedears": "ABBV",
       "Name": "AbbVie Inc.",
       "Market": "NYSE",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "ABBV"
     },
     {
       "Cedears": "ABEV",
       "Name": "Ambev S.A.",
       "Market": "NASDAQ",
-      "Ratio": "1:3"
+      "Ratio": "1:3",
+      "TickerOriginal": "ABEV"
     },
     {
       "Cedears": "ABEV3",
       "Name": "Ambev S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "ABEV3"
     },
     {
       "Cedears": "ABNB",
       "Name": "Airbnb Inc",
       "Market": "NASDAQ GS",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "ABNB"
     },
     {
       "Cedears": "ABT",
       "Name": "Abbott Labs",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "ABT"
     },
     {
       "Cedears": "ACN",
       "Name": "Accenture",
       "Market": "NYSE",
-      "Ratio": "75"
+      "Ratio": "75",
+      "TickerOriginal": "ACN"
     },
     {
       "Cedears": "ACWI",
       "Name": "iShares MSCI ACWI ETF",
       "Market": "NASDAQ",
-      "Ratio": "26"
+      "Ratio": "26",
+      "TickerOriginal": "ACWI"
     },
     {
       "Cedears": "ADBE",
       "Name": "Adobe Systems Incorporated",
       "Market": "NASDAQ",
-      "Ratio": "44"
+      "Ratio": "44",
+      "TickerOriginal": "ADBE"
     },
     {
       "Cedears": "ADGO",
       "Name": "Adecoagro S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "AGRO"
     },
     {
       "Cedears": "ADI",
       "Name": "Analog Devices",
       "Market": "NASDAQ",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "ADI"
     },
     {
       "Cedears": "ADP",
       "Name": "Automatic Data Processing Inc.",
       "Market": "NASDAQ",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "ADP"
     },
     {
       "Cedears": "ADS",
       "Name": "Adidas AG",
       "Market": "XETRA",
-      "Ratio": "22"
+      "Ratio": "22",
+      "TickerOriginal": "ADS"
     },
     {
       "Cedears": "AEG",
       "Name": "Aegon N.V.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "AEG"
     },
     {
       "Cedears": "AEM",
       "Name": "Agnico Eagle Mines Limited",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "AEM"
     },
     {
       "Cedears": "AI",
       "Name": "C3.AI INC",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "AI"
     },
     {
       "Cedears": "AIG",
       "Name": "American International Group (AIG)",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "AIG"
     },
     {
       "Cedears": "AKO.B",
       "Name": "Embotelladora Andina S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "AKO.B"
     },
     {
       "Cedears": "ALAB",
       "Name": "Astera Labs Inc",
       "Market": "NASDAQ",
-      "Ratio": "44"
+      "Ratio": "44",
+      "TickerOriginal": "ALAB"
     },
     {
       "Cedears": "AMAT",
       "Name": "Applied Materials Inc.",
       "Market": "NASDAQ",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "AMAT"
     },
     {
       "Cedears": "AMD",
       "Name": "Advanced Micro Devices, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "AMD"
     },
     {
       "Cedears": "AMGN",
       "Name": "Amgen Inc.",
       "Market": "NASDAQ",
-      "Ratio": "30"
+      "Ratio": "30",
+      "TickerOriginal": "AMGN"
     },
     {
       "Cedears": "AMX",
       "Name": "America Movil",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "AMX"
     },
     {
       "Cedears": "AMZN",
       "Name": "Amazon.Com, Inc.",
       "Market": "NYSE",
-      "Ratio": "144"
+      "Ratio": "144",
+      "TickerOriginal": "AMZN"
     },
     {
       "Cedears": "ANET",
       "Name": "Arista Networks Inc",
       "Market": "NYSE",
-      "Ratio": "29"
+      "Ratio": "29",
+      "TickerOriginal": "ANET"
     },
     {
       "Cedears": "ANF",
       "Name": "Abercrombie & Fitch Co",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "ANF"
     },
     {
       "Cedears": "AOCA",
       "Name": "Aluminum Corp Of China",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "ACH"
     },
     {
       "Cedears": "ARCO",
       "Name": "Arcos Dorados Holdings Inc.",
       "Market": "NYSE",
-      "Ratio": "1:2"
+      "Ratio": "1:2",
+      "TickerOriginal": "ARCO"
     },
     {
       "Cedears": "ARKK",
       "Name": "ARK INNOVATION",
       "Market": "NYSE Arca",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "ARKK"
     },
     {
       "Cedears": "ARM",
       "Name": "ARM Holdings Plc",
       "Market": "NASDAQ",
-      "Ratio": "27"
+      "Ratio": "27",
+      "TickerOriginal": "ARM"
     },
     {
       "Cedears": "ASML",
       "Name": "ASML HOLDING NV",
       "Market": "NASDAQ GS",
-      "Ratio": "146"
+      "Ratio": "146",
+      "TickerOriginal": "ASML"
     },
     {
       "Cedears": "ASR",
       "Name": "Grupo Aeroportuario Del Sureste, S.A.B. de C.V.",
       "Market": "NYSE",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "ASR"
     },
     {
       "Cedears": "ASTS",
       "Name": "AST SpaceMobile Inc",
       "Market": "NASDAQ",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "ASTS"
     },
     {
       "Cedears": "ATAD",
       "Name": "Pjsc Tatneft",
       "Market": "LONDON STOCK EXCHANGE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "ATAD"
     },
     {
       "Cedears": "AUY",
       "Name": "Yamana Gold Inc.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "AUY"
     },
     {
       "Cedears": "AVGO",
       "Name": "Broadcom Inc.",
       "Market": "NASDAQ",
-      "Ratio": "39"
+      "Ratio": "39",
+      "TickerOriginal": "AVGO"
     },
     {
       "Cedears": "AVY",
       "Name": "Avery Dennison Corp.",
       "Market": "NYSE",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "AVY"
     },
     {
       "Cedears": "AXP",
       "Name": "American Express Co",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "AXP"
     },
     {
       "Cedears": "AZN",
       "Name": "Astrazeneca Plc",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "AZN"
     },
     {
       "Cedears": "B",
       "Name": "Barrick Gold Corp",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "B"
     },
     {
       "Cedears": "BA",
       "Name": "The Boeing Company",
       "Market": "NYSE",
-      "Ratio": "24"
+      "Ratio": "24",
+      "TickerOriginal": "BA"
     },
     {
       "Cedears": "BABA",
       "Name": "Alibaba Group Holding Limited",
       "Market": "NYSE",
-      "Ratio": "9"
+      "Ratio": "9",
+      "TickerOriginal": "BABA"
     },
     {
       "Cedears": "BA.C",
       "Name": "Bank Of America Corporation",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "BAC"
     },
     {
       "Cedears": "BAK",
       "Name": "Braskem SA",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "BAK"
     },
     {
       "Cedears": "BAS",
       "Name": "Basf SE",
       "Market": "FRANKFURT",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "BAS"
     },
     {
       "Cedears": "BAYN",
       "Name": "Bayer AG",
       "Market": "FRANKFURT",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "BAYN"
     },
     {
       "Cedears": "BB",
       "Name": "Blackberry Limited",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "BB"
     },
     {
       "Cedears": "BBAS3",
       "Name": "Banco do Brasil S.A.",
       "Market": "B3",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "BBAS3"
     },
     {
       "Cedears": "BBD",
       "Name": "Banco Bradesco S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "BBD"
     },
     {
       "Cedears": "BBDC3",
       "Name": "Banco Bradesco S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "BBDC3"
     },
     {
       "Cedears": "BBV",
       "Name": "Bilbao Vizcaya Argentaria S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "BBV"
     },
     {
       "Cedears": "BCS",
       "Name": "Barclays Bank Plc",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "BCS"
     },
     {
       "Cedears": "BHP",
       "Name": "Bhp Group Ltd",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "BHP"
     },
     {
       "Cedears": "BIDU",
       "Name": "Baidu, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "11"
+      "Ratio": "11",
+      "TickerOriginal": "BIDU"
     },
     {
       "Cedears": "BIIB",
       "Name": "Biogen Inc.",
       "Market": "NASDAQ",
-      "Ratio": "13"
+      "Ratio": "13",
+      "TickerOriginal": "BIIB"
     },
     {
       "Cedears": "BIOX",
       "Name": "Bioceres Crop Solutions Corp.",
       "Market": "NYSE American",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "BIOX"
     },
     {
       "Cedears": "BK",
       "Name": "The Bank Of New York Mellon Corp.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "BK"
     },
     {
       "Cedears": "BKNG",
       "Name": "Booking",
       "Market": "NASDAQ",
-      "Ratio": "700"
+      "Ratio": "700",
+      "TickerOriginal": "BKNG"
     },
     {
       "Cedears": "BKR",
       "Name": "Baker Hughes Co",
       "Market": "NASDAQ",
-      "Ratio": "7"
+      "Ratio": "7",
+      "TickerOriginal": "BKR"
     },
     {
       "Cedears": "BMNR",
       "Name": "Bitmine Inmersion Technologies, Inc.",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "BMNR"
     },
     {
       "Cedears": "BMY",
       "Name": "Bristol-Myers Squibb Company",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "BMY"
     },
     {
       "Cedears": "BNG",
       "Name": "Bunge Limited",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "BNG"
     },
     {
       "Cedears": "BP",
       "Name": "BP PCL",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "BP"
     },
     {
       "Cedears": "BPA11",
       "Name": "Banco BTG Pactual S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "BPA11"
     },
     {
       "Cedears": "BRFS",
       "Name": "BRF S.A.",
       "Market": "NYSE",
-      "Ratio": "1:3"
+      "Ratio": "1:3",
+      "TickerOriginal": "BRFS"
     },
     {
       "Cedears": "BRKB",
       "Name": "Berkshire Hathaway Inc.",
       "Market": "NYSE",
-      "Ratio": "22"
+      "Ratio": "22",
+      "TickerOriginal": "BRKB"
     },
     {
       "Cedears": "BSBR",
       "Name": "Banco Santander (Brasil) S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "BSBR"
     },
     {
       "Cedears": "BSN",
       "Name": "Danone",
       "Market": "FRANKFURT",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "BSN"
     },
     {
       "Cedears": "BX",
       "Name": "Blackstone Inc.",
       "Market": "NYSE",
-      "Ratio": "30"
+      "Ratio": "30",
+      "TickerOriginal": "BX"
     },
     {
       "Cedears": "C",
       "Name": "Citigroup Inc",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "C"
     },
     {
       "Cedears": "CAAP",
       "Name": "Corporación America Airports S.A.",
       "Market": "NYSE",
-      "Ratio": "1:4"
+      "Ratio": "1:4",
+      "TickerOriginal": "CAAP"
     },
     {
       "Cedears": "CAH",
       "Name": "Cardinal Health Inc",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "CAH"
     },
     {
       "Cedears": "CAJ",
       "Name": "Canon Inc",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "CAJ"
     },
     {
       "Cedears": "CAR",
       "Name": "Avis Budget Group Inc.",
       "Market": "NASDAQ",
-      "Ratio": "26"
+      "Ratio": "26",
+      "TickerOriginal": "CAR"
     },
     {
       "Cedears": "CAT",
       "Name": "Caterpillar Inc",
       "Market": "NYSE",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "CAT"
     },
     {
       "Cedears": "CBRD",
       "Name": "Companhia Brasileira De Dis NPV ADR",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "CBRD"
     },
     {
       "Cedears": "CCJ",
       "Name": "Cameco Corporation",
       "Market": "NYSE",
-      "Ratio": "23"
+      "Ratio": "23",
+      "TickerOriginal": "CCJ"
     },
     {
       "Cedears": "CCL",
       "Name": "Carnival",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "CCL"
     },
     {
       "Cedears": "CDE",
       "Name": "Coeur Mining Inc.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "CDE"
     },
     {
       "Cedears": "CEG",
       "Name": "CONSTELLATION ENERGY CORPORATION",
       "Market": "NASDAQ GS",
-      "Ratio": "45"
+      "Ratio": "45",
+      "TickerOriginal": "CEG"
     },
     {
       "Cedears": "CIBR",
       "Name": "First Trust NASDAQ Cybersecurity",
       "Market": "NASDAQ GM",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "CIBR"
     },
     {
       "Cedears": "CL",
       "Name": "Colgate Palmolive Co",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "CL"
     },
     {
       "Cedears": "CLS",
       "Name": "CELESTICA INC",
       "Market": "NYSE",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "CLS"
     },
     {
       "Cedears": "COIN",
       "Name": "Coinbase Global Inc",
       "Market": "NASDAQ",
-      "Ratio": "27"
+      "Ratio": "27",
+      "TickerOriginal": "COIN"
     },
     {
       "Cedears": "COP",
       "Name": "ConocoPhillips",
       "Market": "NYSE",
-      "Ratio": "25"
+      "Ratio": "25",
+      "TickerOriginal": "COP"
     },
     {
       "Cedears": "COPX",
       "Name": "Global X Copper Miners ETF",
       "Market": "NYSE",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "COPX"
     },
     {
       "Cedears": "COST",
       "Name": "Costco Wholesale Corp",
       "Market": "NASDAQ",
-      "Ratio": "48"
+      "Ratio": "48",
+      "TickerOriginal": "COST"
     },
     {
       "Cedears": "CRM",
       "Name": "Salesforce Inc.",
       "Market": "NYSE",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "CRM"
     },
     {
       "Cedears": "CRWD",
       "Name": "CrowdStrike Holdings, Inc.",
       "Market": "NASDAQ GS",
-      "Ratio": "79"
+      "Ratio": "79",
+      "TickerOriginal": "CRWD"
     },
     {
       "Cedears": "CRWV",
       "Name": "CoreWeave Inc",
       "Market": "NASDAQ",
-      "Ratio": "27"
+      "Ratio": "27",
+      "TickerOriginal": "CRWV"
     },
     {
       "Cedears": "CS",
       "Name": "Credit Suisse Group",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "CS"
     },
     {
       "Cedears": "CSCO",
       "Name": "Cisco Systems Inc",
       "Market": "NASDAQ",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "CSCO"
     },
     {
       "Cedears": "CSNA3",
       "Name": "Companhia Siderúrgica Nacional S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "CSNA3"
     },
     {
       "Cedears": "CVS",
       "Name": "CVS Health",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "CVS"
     },
     {
       "Cedears": "CVX",
       "Name": "Chevron Corp.",
       "Market": "NYSE",
-      "Ratio": "16"
+      "Ratio": "16",
+      "TickerOriginal": "CVX"
     },
     {
       "Cedears": "CX",
       "Name": "Cemex S.A.B. de CV",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "CX"
     },
     {
       "Cedears": "DAL",
       "Name": "Delta Air Lines",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "DAL"
     },
     {
       "Cedears": "DD",
       "Name": "Dupont de Nemours Inc.",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "DD"
     },
     {
       "Cedears": "DE",
       "Name": "Deere & Co.",
       "Market": "NYSE",
-      "Ratio": "40"
+      "Ratio": "40",
+      "TickerOriginal": "DE"
     },
     {
       "Cedears": "DECK",
       "Name": "DECKERS OUTDOOR CORPORATION",
       "Market": "NYSE",
-      "Ratio": "25"
+      "Ratio": "25",
+      "TickerOriginal": "DECK"
     },
     {
       "Cedears": "DEO",
       "Name": "Diageo PLC",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "DEO"
     },
     {
       "Cedears": "DHR",
       "Name": "Danaher Corp",
       "Market": "NYSE",
-      "Ratio": "54"
+      "Ratio": "54",
+      "TickerOriginal": "DHR"
     },
     {
       "Cedears": "DIA",
       "Name": "SPDR DOW JONES INDUSTRIAL",
       "Market": "NYSE Arca",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "DIA"
     },
     {
       "Cedears": "DISN",
       "Name": "The Walt Disney Co.",
       "Market": "NYSE",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "DISN"
     },
     {
       "Cedears": "DOCU",
       "Name": "DocuSign Inc.",
       "Market": "NASDAQ",
-      "Ratio": "22"
+      "Ratio": "22",
+      "TickerOriginal": "DOCU"
     },
     {
       "Cedears": "DOW",
       "Name": "DOW Inc",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "DOW"
     },
     {
       "Cedears": "DTEA",
       "Name": "Deutsche Telekom Ag",
       "Market": "OTC US",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "DTEA"
     },
     {
       "Cedears": "E",
       "Name": "Eni Spa",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "E"
     },
     {
       "Cedears": "EA",
       "Name": "Electronic Arts Inc",
       "Market": "NASDAQ",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "EA"
     },
     {
       "Cedears": "EBAY",
       "Name": "Ebay Inc.",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "EBAY"
     },
     {
       "Cedears": "EBR",
       "Name": "Centrais Eléctricas Brasileiras S.A. - Eletrobras",
       "Market": "NYSE",
-      "Ratio": "1:4"
+      "Ratio": "1:4",
+      "TickerOriginal": "EBR"
     },
     {
       "Cedears": "ECL",
       "Name": "Ecolab Inc",
       "Market": "NYSE",
-      "Ratio": "56"
+      "Ratio": "56",
+      "TickerOriginal": "ECL"
     },
     {
       "Cedears": "EEM",
       "Name": "ISHARES MSCI EMERGING MARKET",
       "Market": "NYSE Arca",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "EEM"
     },
     {
       "Cedears": "EFA",
       "Name": "iShares MSCI EAFE ETF",
       "Market": "NYSE",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "EFA"
     },
     {
       "Cedears": "EFX",
       "Name": "Equifax Inc.",
       "Market": "NYSE",
-      "Ratio": "16"
+      "Ratio": "16",
+      "TickerOriginal": "EFX"
     },
     {
       "Cedears": "ELP",
       "Name": "Companhia Paranaense de Energía - COPEL",
       "Market": "NYSE",
-      "Ratio": "1:3"
+      "Ratio": "1:3",
+      "TickerOriginal": "ELP"
     },
     {
       "Cedears": "EOAN",
       "Name": "E.On Se",
       "Market": "FRANKFURT",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "EOAN"
     },
     {
       "Cedears": "EQNR",
       "Name": "Equinor Asa",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "EQNR"
     },
     {
       "Cedears": "ERIC",
       "Name": "Lm Ericsson Telephone Co.",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "ERIC"
     },
     {
       "Cedears": "ERJ",
       "Name": "Embraer-Empresa Brasileira de Aeronáutica S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "ERJ"
     },
     {
       "Cedears": "ESGU",
       "Name": "IShares ESG Aware MSCI USA ETF",
       "Market": "NASDAQ",
-      "Ratio": "30"
+      "Ratio": "30",
+      "TickerOriginal": "ESGU"
     },
     {
       "Cedears": "ETHA",
       "Name": "ISHARES ETHEREUM TR ETF",
       "Market": "NASDAQ",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "ETHA"
     },
     {
       "Cedears": "ETSY",
       "Name": "Etsy Inc.",
       "Market": "NASDAQ",
-      "Ratio": "16"
+      "Ratio": "16",
+      "TickerOriginal": "ETSY"
     },
     {
       "Cedears": "EWJ",
       "Name": "iShares MSCI JAPAN ETF",
       "Market": "NYSE Arca",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "EWJ"
     },
     {
       "Cedears": "EWY",
       "Name": "iShares MSCI South Korea ETF",
       "Market": "NYSE ARCA",
-      "Ratio": "50"
+      "Ratio": "50",
+      "TickerOriginal": "EWY"
     },
     {
       "Cedears": "EWZ",
       "Name": "ISHARES MSCI BRAZIL CAP",
       "Market": "NYSE Arca",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "EWZ"
     },
     {
       "Cedears": "F",
       "Name": "Ford Motor Company",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "F"
     },
     {
       "Cedears": "FCX",
       "Name": "Freeport Mcmoran Copper & Gold Inc.",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "FCX"
     },
     {
       "Cedears": "FDX",
       "Name": "Fedex Corp",
       "Market": "NYSE",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "FDX"
     },
     {
       "Cedears": "FISV",
       "Name": "Fiserv, Inc.",
       "Market": "NASDAQ GS",
-      "Ratio": "11"
+      "Ratio": "11",
+      "TickerOriginal": "FISV"
     },
     {
       "Cedears": "FMCC",
       "Name": "Freddie Mac (Federal Home Loan)",
       "Market": "OTC",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "FMCC"
     },
     {
       "Cedears": "FMX",
       "Name": "Fomento Economico Mexicano - Femsa",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "FMX"
     },
     {
       "Cedears": "FNMA",
       "Name": "Fed. Natl, Mortgage - Fannie Mae",
       "Market": "OTC",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "FNMA"
     },
     {
       "Cedears": "FSLR",
       "Name": "First Solar Inc.",
       "Market": "NASDAQ",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "FSLR"
     },
     {
       "Cedears": "FXI",
       "Name": "ISHARES CHINA LARGE-CAP ETF",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "FXI"
     },
     {
       "Cedears": "GDX",
       "Name": "Van Eck Gold Miners ETF/USA",
       "Market": "NYSE",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "GDX"
     },
     {
       "Cedears": "GE",
       "Name": "General Electric Co.",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "GE"
     },
     {
       "Cedears": "GFI",
       "Name": "Gold Fields Ltd.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "GFI"
     },
     {
       "Cedears": "GGB",
       "Name": "Gerdau S.A.",
       "Market": "NYSE",
-      "Ratio": "1:4"
+      "Ratio": "1:4",
+      "TickerOriginal": "GGB"
     },
     {
       "Cedears": "GILD",
       "Name": "Gilead Sciences, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "GILD"
     },
     {
       "Cedears": "GLD",
       "Name": "ETF SPDR GOLD TRUST",
       "Market": "NYSE",
-      "Ratio": "50"
+      "Ratio": "50",
+      "TickerOriginal": "GLD"
     },
     {
       "Cedears": "GLNG",
       "Name": "Golar LNG Ltd.",
       "Market": "NASDAQ GS",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "GLNG"
     },
     {
       "Cedears": "GLOB",
       "Name": "Globant S.A.",
       "Market": "NYSE",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "GLOB"
     },
     {
       "Cedears": "GLW",
       "Name": "Corning Inc.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "GLW"
     },
     {
       "Cedears": "GM",
       "Name": "General Motors Co",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "GM"
     },
     {
       "Cedears": "GOOGL",
       "Name": "Alphabet Inc.",
       "Market": "NASDAQ",
-      "Ratio": "58"
+      "Ratio": "58",
+      "TickerOriginal": "GOOGL"
     },
     {
       "Cedears": "GPRK",
       "Name": "Geopark Ltd.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "GPRK"
     },
     {
       "Cedears": "GRMN",
       "Name": "Garmin Ltd.",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "GRMN"
     },
     {
       "Cedears": "GS",
       "Name": "The Goldman Sachs Group, Inc",
       "Market": "NYSE",
-      "Ratio": "13"
+      "Ratio": "13",
+      "TickerOriginal": "GS"
     },
     {
       "Cedears": "GSK",
       "Name": "GSK Plc.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "GSK"
     },
     {
       "Cedears": "GT",
       "Name": "Goodyear Tire & Rubber co./the",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "GT"
     },
     {
       "Cedears": "HAL",
       "Name": "Halliburton Co.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "HAL"
     },
     {
       "Cedears": "HAPV3",
       "Name": "Hapvida Participacoes E Investimentos S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "HAPV3"
     },
     {
       "Cedears": "HD",
       "Name": "The Home Depot Inc.",
       "Market": "NYSE",
-      "Ratio": "32"
+      "Ratio": "32",
+      "TickerOriginal": "HD"
     },
     {
       "Cedears": "HDB",
       "Name": "Hdfc Bank Limited.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "HDB"
     },
     {
       "Cedears": "HHPD",
       "Name": "Hon Hai Precision Industry Co. Ltd.",
       "Market": "LONDON STOCK EXCHANGE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "HHPD"
     },
     {
       "Cedears": "HIMS",
       "Name": "Hims & Hers Health, Inc.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "HIMS"
     },
     {
       "Cedears": "HL",
       "Name": "Hecla Mining Co.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "HL"
     },
     {
       "Cedears": "HMC",
       "Name": "Honda Motor Co. Ltd",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "HMC"
     },
     {
       "Cedears": "HMY",
       "Name": "Harmony Gold Mining Company Ltd.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "HMY"
     },
     {
       "Cedears": "HNPIY",
       "Name": "Huaneng Power Intl",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "HNPIY"
     },
     {
       "Cedears": "HOG",
       "Name": "Harley-Davidson Inc.",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "HOG"
     },
     {
       "Cedears": "HON",
       "Name": "Honeywell International Inc.",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "HON"
     },
     {
       "Cedears": "HOOD",
       "Name": "Robinhood Markets Inc",
       "Market": "NASDAQ",
-      "Ratio": "29"
+      "Ratio": "29",
+      "TickerOriginal": "HOOD"
     },
     {
       "Cedears": "HPQ",
       "Name": "Hp Inc",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "HPQ"
     },
     {
       "Cedears": "HSBC",
       "Name": "Hsbc Holdings Plc",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "HSBC"
     },
     {
       "Cedears": "HSY",
       "Name": "The Hershey Company",
       "Market": "NYSE",
-      "Ratio": "21"
+      "Ratio": "21",
+      "TickerOriginal": "HSY"
     },
     {
       "Cedears": "HUT",
       "Name": "Hut 8 Mining Corp.",
       "Market": "NASDAQ GS",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "HUT"
     },
     {
       "Cedears": "HWM",
       "Name": "Howmet Aerospace Inc.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "HWM"
     },
     {
       "Cedears": "IBB",
       "Name": "iShares Nasdaq Biotechnology ETF",
       "Market": "NASDAQ",
-      "Ratio": "27"
+      "Ratio": "27",
+      "TickerOriginal": "IBB"
     },
     {
       "Cedears": "IBIT",
       "Name": "ISHARES BITCOIN TRUST",
       "Market": "NASDAQ",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "IBIT"
     },
     {
       "Cedears": "IBM",
       "Name": "International Business Machines",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "IBM"
     },
     {
       "Cedears": "IBN",
       "Name": "Icici Bank Ltd.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "IBN"
     },
     {
       "Cedears": "ICLN",
       "Name": "iShares Global Clean Energy ETF",
       "Market": "NASDAQ GM",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "ICLN"
     },
     {
       "Cedears": "IEMG",
       "Name": "iShares Core MSCI Emerging Markets ETF",
       "Market": "NYSE",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "IEMG"
     },
     {
       "Cedears": "IEUR",
       "Name": "iShares Core MSCI Europe ETF",
       "Market": "NYSE Arca",
-      "Ratio": "11"
+      "Ratio": "11",
+      "TickerOriginal": "IEUR"
     },
     {
       "Cedears": "IFF",
       "Name": "International Flavors & Fragrances Inc.",
       "Market": "NYSE",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "IFF"
     },
     {
       "Cedears": "IJH",
       "Name": "iShares CORE S&P MID-CAP ETF",
       "Market": "NYSE Arca",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "IJH"
     },
     {
       "Cedears": "ILF",
       "Name": "IShares Latin America 40 ETF",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "ILF"
     },
     {
       "Cedears": "INFY",
       "Name": "Infosys Limited",
       "Market": "NASDAQ",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "INFY"
     },
     {
       "Cedears": "ING",
       "Name": "Ing Groep Nv",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "ING"
     },
     {
       "Cedears": "INTC",
       "Name": "Intel Corporation",
       "Market": "NASDAQ",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "INTC"
     },
     {
       "Cedears": "IP",
       "Name": "International Paper Co.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "IP"
     },
     {
       "Cedears": "IREN",
       "Name": "Iren Ltd",
       "Market": "NASDAQ",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "IREN"
     },
     {
       "Cedears": "ISRG",
       "Name": "Intuitive Surgical inc",
       "Market": "NASDAQ",
-      "Ratio": "90"
+      "Ratio": "90",
+      "TickerOriginal": "ISRG"
     },
     {
       "Cedears": "ITA",
       "Name": "iShares U.S. Aerospace & Defense",
       "Market": "CBOE",
-      "Ratio": "50"
+      "Ratio": "50",
+      "TickerOriginal": "ITA"
     },
     {
       "Cedears": "ITUB",
       "Name": "Itaú Unibanco Holding S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "ITUB"
     },
     {
       "Cedears": "ITUB3",
       "Name": "Banco Itaú Unibanco S.A",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "ITUB3"
     },
     {
       "Cedears": "IVE",
       "Name": "iShares S&P 500 Value ETF",
       "Market": "NYSE Arca",
-      "Ratio": "40"
+      "Ratio": "40",
+      "TickerOriginal": "IVE"
     },
     {
       "Cedears": "IVV",
       "Name": "IShares Core S&P 500 ETF",
       "Market": "NYSE",
-      "Ratio": "692"
+      "Ratio": "692",
+      "TickerOriginal": "IVV"
     },
     {
       "Cedears": "IVW",
       "Name": "iShares S&P 500 Growth ETF",
       "Market": "NYSE Arca",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "IVW"
     },
     {
       "Cedears": "IWM",
       "Name": "ISHARES TRUST RUSSELL 2000",
       "Market": "NYSE Arca",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "IWM"
     },
     {
       "Cedears": "JCI",
       "Name": "Johnson Controls International",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "JCI"
     },
     {
       "Cedears": "JD",
       "Name": "Jd.Com, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "JD"
     },
     {
       "Cedears": "JMIA",
       "Name": "Adr Jumia Technologies Ag",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "JMIA"
     },
     {
       "Cedears": "JNJ",
       "Name": "Johnson & Johnson",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "JNJ"
     },
     {
       "Cedears": "JOYY",
       "Name": "JOYY Inc.",
       "Market": "NASDAQ",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "JOYY"
     },
     {
       "Cedears": "JPM",
       "Name": "J.P. Morgan & Chase Co.",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "JPM"
     },
     {
       "Cedears": "KB",
       "Name": "Kb Financial Group Inc.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "KB"
     },
     {
       "Cedears": "KEEL",
       "Name": "Bitfarms Ltd.",
       "Market": "NASDAQ GM",
-      "Ratio": "1:5"
+      "Ratio": "1:5",
+      "TickerOriginal": "KEEL"
     },
     {
       "Cedears": "KEP",
       "Name": "Korea Electric Power Corp.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "KEP"
     },
     {
       "Cedears": "KGC",
       "Name": "Kinross Gold Corp",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "KGC"
     },
     {
       "Cedears": "KMB",
       "Name": "Kimberly-Clark Corp.",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "KMB"
     },
     {
       "Cedears": "KO",
       "Name": "The Coca Cola Company",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "KO"
     },
     {
       "Cedears": "KOFM",
       "Name": "Coca-Cola Femsa, S.A.B. De C.V.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "KOFM"
     },
     {
       "Cedears": "LAC",
       "Name": "Lithium Americas Corp",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "LAC"
     },
     {
       "Cedears": "LAR",
       "Name": "Lithium Americas (Argentina) Corp",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "LAR"
     },
     {
       "Cedears": "LFC",
       "Name": "China Life Insurance",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "LFC"
     },
     {
       "Cedears": "LKOD",
       "Name": "Pjsc Lukoil",
       "Market": "LONDON STOCK EXCHANGE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "LKOD"
     },
     {
       "Cedears": "LLY",
       "Name": "Eli Lilly and Company",
       "Market": "NYSE",
-      "Ratio": "56"
+      "Ratio": "56",
+      "TickerOriginal": "LLY"
     },
     {
       "Cedears": "LMT",
       "Name": "Lockheed Martin Corporation",
       "Market": "NYSE",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "LMT"
     },
     {
       "Cedears": "LND",
       "Name": "Brasilagro - Co Brasileira de Propriedades Agrícolas",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "LND"
     },
     {
       "Cedears": "LRCX",
       "Name": "Lam Research Corp",
       "Market": "NASDAQ",
-      "Ratio": "56"
+      "Ratio": "56",
+      "TickerOriginal": "LRCX"
     },
     {
       "Cedears": "LREN3",
       "Name": "Lojas Renner S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "LREN3"
     },
     {
       "Cedears": "LVS",
       "Name": "Las Vegas Sands Corp",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "LVS"
     },
     {
       "Cedears": "LYG",
       "Name": "Lloyds Banking Group Plc",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "LYG"
     },
     {
       "Cedears": "MA",
       "Name": "Mastercard Inc.",
       "Market": "NYSE",
-      "Ratio": "33"
+      "Ratio": "33",
+      "TickerOriginal": "MA"
     },
     {
       "Cedears": "MBG",
       "Name": "Mercedes-Benz Group AG",
       "Market": "FRANKFURT",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "MBG"
     },
     {
       "Cedears": "MBT",
       "Name": "Mobile Telesystems",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "MBT"
     },
     {
       "Cedears": "MCD",
       "Name": "Mcdonald'S Corp.",
       "Market": "NYSE",
-      "Ratio": "24"
+      "Ratio": "24",
+      "TickerOriginal": "MCD"
     },
     {
       "Cedears": "MDLZ",
       "Name": "Mondelez",
       "Market": "NASDAQ",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "MDLZ"
     },
     {
       "Cedears": "MDT",
       "Name": "Medtronic Public Limited Company",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "MDT"
     },
     {
       "Cedears": "MELI",
       "Name": "Mercadolibre Inc.",
       "Market": "NASDAQ",
-      "Ratio": "120"
+      "Ratio": "120",
+      "TickerOriginal": "MELI"
     },
     {
       "Cedears": "META",
       "Name": "Meta Platforms Inc",
       "Market": "NASDAQ",
-      "Ratio": "24"
+      "Ratio": "24",
+      "TickerOriginal": "META"
     },
     {
       "Cedears": "MFG",
       "Name": "Mizuho Financial Group",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "MFG"
     },
     {
       "Cedears": "MGLU3",
       "Name": "Magazine Luiza S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "MGLU3"
     },
     {
       "Cedears": "MMC",
       "Name": "Marsh & Mclennan Companies Inc.",
       "Market": "NYSE",
-      "Ratio": "16"
+      "Ratio": "16",
+      "TickerOriginal": "MMC"
     },
     {
       "Cedears": "MMM",
       "Name": "3M Company",
       "Market": "NYSE",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "MMM"
     },
     {
       "Cedears": "MO",
       "Name": "Altria Group Inc.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "MO"
     },
     {
       "Cedears": "MOS",
       "Name": "The Mosaic Co",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "MOS"
     },
     {
       "Cedears": "MP",
       "Name": "MP Materials Corp.",
       "Market": "NYSE",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "MP"
     },
     {
       "Cedears": "MRK",
       "Name": "Merck & Co. Inc.",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "MRK"
     },
     {
       "Cedears": "MRNA",
       "Name": "Moderna Inc",
       "Market": "NASDAQ",
-      "Ratio": "19"
+      "Ratio": "19",
+      "TickerOriginal": "MRNA"
     },
     {
       "Cedears": "MRVL",
       "Name": "Marvell Technology Inc",
       "Market": "NASDAQ",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "MRVL"
     },
     {
       "Cedears": "MSFT",
       "Name": "Microsoft Corp.",
       "Market": "NASDAQ",
-      "Ratio": "30"
+      "Ratio": "30",
+      "TickerOriginal": "MSFT"
     },
     {
       "Cedears": "MSI",
       "Name": "Motorola Solutions, Inc.",
       "Market": "NYSE",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "MSI"
     },
     {
       "Cedears": "MSTR",
       "Name": "Microstrategy Inc Cl A New",
       "Market": "NASDAQ GS",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "MSTR"
     },
     {
       "Cedears": "MU",
       "Name": "Micron Technology Inc",
       "Market": "NASDAQ GS",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "MU"
     },
     {
       "Cedears": "MUFG",
       "Name": "Mitsubishi Ufj Financial Group",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "MUFG"
     },
     {
       "Cedears": "MUX",
       "Name": "McEwen Mining Inc",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "MUX"
     },
     {
       "Cedears": "NATU3",
       "Name": "Natura Cosméticos S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "NATU3"
     },
     {
       "Cedears": "NBIS",
       "Name": "Nebius Group N.V.",
       "Market": "NASDAQ GS",
-      "Ratio": "27"
+      "Ratio": "27",
+      "TickerOriginal": "NBIS"
     },
     {
       "Cedears": "NEC1",
       "Name": "Nec Corporation",
       "Market": "FRANKFURT",
-      "Ratio": "1:3"
+      "Ratio": "1:3",
+      "TickerOriginal": "NEC1"
     },
     {
       "Cedears": "NEE",
       "Name": "NextEra Energy, Inc.",
       "Market": "NYSE",
-      "Ratio": "19"
+      "Ratio": "19",
+      "TickerOriginal": "NEE"
     },
     {
       "Cedears": "NEM",
       "Name": "Newmont Corporation",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "NEM"
     },
     {
       "Cedears": "NFLX",
       "Name": "Netflix, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "48"
+      "Ratio": "48",
+      "TickerOriginal": "NFLX"
     },
     {
       "Cedears": "NG",
       "Name": "Novagold Resources INC.",
       "Market": "NYSE",
-      "Ratio": "1:4"
+      "Ratio": "1:4",
+      "TickerOriginal": "NG"
     },
     {
       "Cedears": "NGG",
       "Name": "National Grid Plc",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "NGG"
     },
     {
       "Cedears": "NIO",
       "Name": "NIO Inc.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "NIO"
     },
     {
       "Cedears": "NKE",
       "Name": "Nike Inc.",
       "Market": "NYSE",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "NKE"
     },
     {
       "Cedears": "NLM",
       "Name": "Novolipetsk Steel PJSC",
       "Market": "LONDON STOCK EXCHANGE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "NLM"
     },
     {
       "Cedears": "NMR",
       "Name": "Nomura Holdings, Inc",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "NMR"
     },
     {
       "Cedears": "NOKA",
       "Name": "Nokia Corporation",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "NOKA"
     },
     {
       "Cedears": "NOW",
       "Name": "SERVICENOW INC",
       "Market": "NYSE",
-      "Ratio": "172"
+      "Ratio": "172",
+      "TickerOriginal": "NOW"
     },
     {
       "Cedears": "NSAN",
       "Name": "Nissan Motor Co., Ltd",
       "Market": "OTC US",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "NSAN"
     },
     {
       "Cedears": "NTES",
       "Name": "Netease, Inc",
       "Market": "NASDAQ",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "NTES"
     },
     {
       "Cedears": "NUE",
       "Name": "Nucor Corp",
       "Market": "NYSE",
-      "Ratio": "16"
+      "Ratio": "16",
+      "TickerOriginal": "NUE"
     },
     {
       "Cedears": "NVDA",
       "Name": "Nvidia Corporation",
       "Market": "NASDAQ",
-      "Ratio": "24"
+      "Ratio": "24",
+      "TickerOriginal": "NVDA"
     },
     {
       "Cedears": "NVO",
       "Name": "Novo Nordisk A/S",
       "Market": "NYSE",
-      "Ratio": "7"
+      "Ratio": "7",
+      "TickerOriginal": "NVO"
     },
     {
       "Cedears": "NVS",
       "Name": "Novartis Ag",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "NVS"
     },
     {
       "Cedears": "NXE",
       "Name": "Nexgen Energy LTD",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "NXE"
     },
     {
       "Cedears": "O",
       "Name": "Realty Income Corp.",
       "Market": "NYSE",
-      "Ratio": "13"
+      "Ratio": "13",
+      "TickerOriginal": "O"
     },
     {
       "Cedears": "OGZD",
       "Name": "Pjsc Gazprom",
       "Market": "LONDON STOCK EXCHANGE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "OGZD"
     },
     {
       "Cedears": "OKLO",
       "Name": "Oklo Inc",
       "Market": "NYSE",
-      "Ratio": "28"
+      "Ratio": "28",
+      "TickerOriginal": "OKLO"
     },
     {
       "Cedears": "ONDS",
       "Name": "Ondas Holdings Inc.",
       "Market": "NASDAQ CM",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "ONDS"
     },
     {
       "Cedears": "ORAN",
       "Name": "Orange S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "ORAN"
     },
     {
       "Cedears": "ORCL",
       "Name": "Oracle Corporation",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "ORCL"
     },
     {
       "Cedears": "ORLY",
       "Name": "O'reilly Automotive Inc",
       "Market": "NASDAQ",
-      "Ratio": "222"
+      "Ratio": "222",
+      "TickerOriginal": "ORLY"
     },
     {
       "Cedears": "OXY",
       "Name": "Occidental Petroleum Corp.",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "OXY"
     },
     {
       "Cedears": "PAAS",
       "Name": "Pan American Silver Corp.",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "PAAS"
     },
     {
       "Cedears": "PAC",
       "Name": "Grupo Aeroportuario del Pacifico, S.A.B. de C.V.",
       "Market": "NYSE",
-      "Ratio": "16"
+      "Ratio": "16",
+      "TickerOriginal": "PAC"
     },
     {
       "Cedears": "PAGS",
       "Name": "Pagseguro Digital Ltd",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "PAGS"
     },
     {
       "Cedears": "PANW",
       "Name": "Palo Alto Networks Inc",
       "Market": "NASDAQ GS",
-      "Ratio": "50"
+      "Ratio": "50",
+      "TickerOriginal": "PANW"
     },
     {
       "Cedears": "PATH",
       "Name": "UIPATH INC",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "PATH"
     },
     {
       "Cedears": "PBI",
       "Name": "Pitney Bowes Inc",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "PBI"
     },
     {
       "Cedears": "PBR",
       "Name": "Petrobras (ADR)",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "PBR"
     },
     {
       "Cedears": "PCAR",
       "Name": "Paccar Inc.",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "PCAR"
     },
     {
       "Cedears": "PCRF",
       "Name": "Panasonic Corporation",
       "Market": "OTC US",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "PCRF"
     },
     {
       "Cedears": "PDD",
       "Name": "PDD HOLDINGS INC",
       "Market": "NASDAQ GS",
-      "Ratio": "25"
+      "Ratio": "25",
+      "TickerOriginal": "PDD"
     },
     {
       "Cedears": "PEP",
       "Name": "Pepsico Inc",
       "Market": "NASDAQ",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "PEP"
     },
     {
       "Cedears": "PETR3",
       "Name": "Petrobras - Petróleo Brasileiro S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "PETR3"
     },
     {
       "Cedears": "PFE",
       "Name": "Pfizer Inc.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "PFE"
     },
     {
       "Cedears": "PG",
       "Name": "Procter & Gamble",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "PG"
     },
     {
       "Cedears": "PHG",
       "Name": "Koninklijke Philips N.V.",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "PHG"
     },
     {
       "Cedears": "PINS",
       "Name": "Pinterest",
       "Market": "NYSE",
-      "Ratio": "7"
+      "Ratio": "7",
+      "TickerOriginal": "PINS"
     },
     {
       "Cedears": "PKS",
       "Name": "Posco Holdings Inc.",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "PKS"
     },
     {
       "Cedears": "PLTR",
       "Name": "Palantir Technologies Inc",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "PLTR"
     },
     {
       "Cedears": "PM",
       "Name": "Philip Morris International",
       "Market": "NYSE",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "PM"
     },
     {
       "Cedears": "PRIO3",
       "Name": "Petro Rio S.A.",
       "Market": "B3",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "PRIO3"
     },
     {
       "Cedears": "PSO",
       "Name": "Pearson Plc",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "PSO"
     },
     {
       "Cedears": "PSQ",
       "Name": "PROSHARES SHORT QQQ",
       "Market": "NYSE Arca",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "PSQ"
     },
     {
       "Cedears": "PSX",
       "Name": "Phillips 66",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "PSX"
     },
     {
       "Cedears": "PTR",
       "Name": "Petrochina Co Ltd",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "PTR"
     },
     {
       "Cedears": "PYPL",
       "Name": "Paypal Holdings, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "PYPL"
     },
     {
       "Cedears": "QCOM",
       "Name": "Qualcomm Inc.",
       "Market": "NASDAQ",
-      "Ratio": "11"
+      "Ratio": "11",
+      "TickerOriginal": "QCOM"
     },
     {
       "Cedears": "QQQ",
       "Name": "INVESCO QQQ TRUST",
       "Market": "NASDAQ",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "QQQ"
     },
     {
       "Cedears": "RACE",
       "Name": "Ferrari",
       "Market": "NYSE",
-      "Ratio": "83"
+      "Ratio": "83",
+      "TickerOriginal": "RACE"
     },
     {
       "Cedears": "RBLX",
       "Name": "Roblox Corp.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "RBLX"
     },
     {
       "Cedears": "RCTB4",
       "Name": "Telebras PN",
       "Market": "BOVESPA",
-      "Ratio": "1:1000"
+      "Ratio": "1:1000",
+      "TickerOriginal": "RCTB4"
     },
     {
       "Cedears": "RGTI",
       "Name": "RIGETTI COMPUTING INC",
       "Market": "NASDAQ CM",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "RGTI"
     },
     {
       "Cedears": "RENT3",
       "Name": "Localiza Rent A Car S.A.",
       "Market": "B3",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "RENT3"
     },
     {
       "Cedears": "RIO",
       "Name": "Rio Tinto Plc",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "RIO"
     },
     {
       "Cedears": "RIOT",
       "Name": "Riot Platforms",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "RIOT"
     },
     {
       "Cedears": "RKLB",
       "Name": "Rocket Lab Corp",
       "Market": "NASDAQ",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "RKLB"
     },
     {
       "Cedears": "ROKU",
       "Name": "Roku",
       "Market": "NASDAQ",
-      "Ratio": "13"
+      "Ratio": "13",
+      "TickerOriginal": "ROKU"
     },
     {
       "Cedears": "ROST",
       "Name": "Ross Stores, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "ROST"
     },
     {
       "Cedears": "RSP",
       "Name": "Invesco S&P 500 Equal Weight ETF",
       "Market": "NYSE ARCA",
-      "Ratio": "30"
+      "Ratio": "30",
+      "TickerOriginal": "RSP"
     },
     {
       "Cedears": "RTX",
       "Name": "Raytheon Technologies Corp",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "RTX"
     },
     {
       "Cedears": "SAN",
       "Name": "Banco Santander S.A",
       "Market": "NYSE",
-      "Ratio": "1:4"
+      "Ratio": "1:4",
+      "TickerOriginal": "SAN"
     },
     {
       "Cedears": "SAP",
       "Name": "Sap Se",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "SAP"
     },
     {
       "Cedears": "SATL",
       "Name": "Satellogic Inc.",
       "Market": "NASDAQ GS",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "SATL"
     },
     {
       "Cedears": "SBS",
       "Name": "Companhia de Saneamento Básico do Estado de São Paulo–Sabesp",
       "Market": "NYSE",
-      "Ratio": "1:2"
+      "Ratio": "1:2",
+      "TickerOriginal": "SBS"
     },
     {
       "Cedears": "SBSP3",
       "Name": "Cia Saneamento Básico de SP",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "SBSP3"
     },
     {
       "Cedears": "SBUX",
       "Name": "Starbucks Corporation",
       "Market": "NASDAQ",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "SBUX"
     },
     {
       "Cedears": "SCCO",
       "Name": "Southern Copper Corp",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "SCCO"
     },
     {
       "Cedears": "SCHW",
       "Name": "Charles Schwab",
       "Market": "NYSE",
-      "Ratio": "13"
+      "Ratio": "13",
+      "TickerOriginal": "SCHW"
     },
     {
       "Cedears": "SDA",
       "Name": "SunCar Technology Group Inc",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "SDA"
     },
     {
       "Cedears": "SE",
       "Name": "Sea Ltd.",
       "Market": "NYSE",
-      "Ratio": "32"
+      "Ratio": "32",
+      "TickerOriginal": "SE"
     },
     {
       "Cedears": "SH",
       "Name": "PROSHARES SHORT S&P500",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "SH"
     },
     {
       "Cedears": "SHEL",
       "Name": "Royal Dutch Shell Plc",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "SHEL"
     },
     {
       "Cedears": "SHOP",
       "Name": "Shopify Inc.",
       "Market": "NYSE",
-      "Ratio": "107"
+      "Ratio": "107",
+      "TickerOriginal": "SHOP"
     },
     {
       "Cedears": "SHPW",
       "Name": "Shapeways Holdings Inc",
       "Market": "NYSE",
-      "Ratio": "1:2"
+      "Ratio": "1:2",
+      "TickerOriginal": "SHPW"
     },
     {
       "Cedears": "SI",
       "Name": "Silvergate Bancorp",
       "Market": "NYSE",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "SI"
     },
     {
       "Cedears": "SID",
       "Name": "Companhia Siderúrgica Nacional",
       "Market": "NYSE",
-      "Ratio": "1:8"
+      "Ratio": "1:8",
+      "TickerOriginal": "SID"
     },
     {
       "Cedears": "SIEGY",
       "Name": "Siemens Ag Adr",
       "Market": "OTC",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "SIEGY"
     },
     {
       "Cedears": "SLB",
       "Name": "Schlumberger Ltd",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "SLB"
     },
     {
       "Cedears": "SLV",
       "Name": "iShares SILVER TRUST",
       "Market": "NYSE Arca",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "SLV"
     },
     {
       "Cedears": "SMH",
       "Name": "VAN ECK SEMICONDUCTOR ETF",
       "Market": "NASDAQ",
-      "Ratio": "50"
+      "Ratio": "50",
+      "TickerOriginal": "SMH"
     },
     {
       "Cedears": "SMSN",
       "Name": "Samsung Electronics Co. Ltd.",
       "Market": "LONDON STOCK EXCHANGE",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "SMSN"
     },
     {
       "Cedears": "SNA",
       "Name": "Snap-On Inc",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "SNA"
     },
     {
       "Cedears": "SNAP",
       "Name": "Snap Inc.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "SNAP"
     },
     {
       "Cedears": "SNDK",
       "Name": "Sandisk Corporation",
       "Market": "NASDAQ GS",
-      "Ratio": "170"
+      "Ratio": "170",
+      "TickerOriginal": "SNDK"
     },
     {
       "Cedears": "SNOW",
       "Name": "Snowflake Inc.",
       "Market": "NYSE",
-      "Ratio": "30"
+      "Ratio": "30",
+      "TickerOriginal": "SNOW"
     },
     {
       "Cedears": "SNP",
       "Name": "China Petroleum & Chem",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "SNP"
     },
     {
       "Cedears": "SONY",
       "Name": "Sony Group Corporation",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "SONY"
     },
     {
       "Cedears": "SPCE",
       "Name": "Virgin Galactic",
       "Market": "NYSE",
-      "Ratio": "1:2"
+      "Ratio": "1:2",
+      "TickerOriginal": "SPCE"
     },
     {
       "Cedears": "SPCX",
       "Name": "Space Exploration Technologies Corp.",
       "Market": "NASDAQ GS",
-      "Ratio": "50"
+      "Ratio": "50",
+      "TickerOriginal": "SPCX"
     },
     {
       "Cedears": "SPGI",
       "Name": "S&P Global Inc",
       "Market": "NYSE",
-      "Ratio": "45"
+      "Ratio": "45",
+      "TickerOriginal": "SPGI"
     },
     {
       "Cedears": "SPHQ",
       "Name": "Invesco S&P 500 Quality ETF",
       "Market": "NYSE ARCA",
-      "Ratio": "14"
+      "Ratio": "14",
+      "TickerOriginal": "SPHQ"
     },
     {
       "Cedears": "SPOT",
       "Name": "Spotify Technology S.A.",
       "Market": "NYSE",
-      "Ratio": "28"
+      "Ratio": "28",
+      "TickerOriginal": "SPOT"
     },
     {
       "Cedears": "SPXL",
       "Name": "DIREXION DAILY S&P 500 BULL 3X",
       "Market": "NYSE Arca",
-      "Ratio": "25"
+      "Ratio": "25",
+      "TickerOriginal": "SPXL"
     },
     {
       "Cedears": "SPY",
       "Name": "SPDR S&P 500",
       "Market": "NYSE Arca",
-      "Ratio": "60"
+      "Ratio": "60",
+      "TickerOriginal": "SPY"
     },
     {
       "Cedears": "STLA",
       "Name": "Stellantis",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "STLA"
     },
     {
       "Cedears": "STNE",
       "Name": "StoneCo Ltd",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "STNE"
     },
     {
       "Cedears": "SUZ",
       "Name": "Suzano Papel E Celulose S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "SUZ"
     },
     {
       "Cedears": "SUZB3",
       "Name": "Suzano S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "SUZB3"
     },
     {
       "Cedears": "SWKS",
       "Name": "Skyworks Solutions",
       "Market": "NASDAQ",
-      "Ratio": "21"
+      "Ratio": "21",
+      "TickerOriginal": "SWKS"
     },
     {
       "Cedears": "SYY",
       "Name": "Sysco Corp.",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "SYY"
     },
     {
       "Cedears": "T",
       "Name": "At &T Inc.",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "T"
     },
     {
       "Cedears": "TCOM",
       "Name": "TRIP.COM Group Ltd.",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "TCOM"
     },
     {
       "Cedears": "TEAM",
       "Name": "ATLASSIAN CORPORATION",
       "Market": "NASDAQ GS",
-      "Ratio": "47"
+      "Ratio": "47",
+      "TickerOriginal": "TEAM"
     },
     {
       "Cedears": "TEFO",
       "Name": "Telefonica S.A.",
       "Market": "NYSE",
-      "Ratio": "8"
+      "Ratio": "8",
+      "TickerOriginal": "TEFO"
     },
     {
       "Cedears": "TEM",
       "Name": "TEMPUS AI INC",
       "Market": "NASDAQ GS",
-      "Ratio": "12"
+      "Ratio": "12",
+      "TickerOriginal": "TEM"
     },
     {
       "Cedears": "TEN",
       "Name": "Tenaris",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "TEN"
     },
     {
       "Cedears": "TGT",
       "Name": "Target Corporation",
       "Market": "NYSE",
-      "Ratio": "24"
+      "Ratio": "24",
+      "TickerOriginal": "TGT"
     },
     {
       "Cedears": "TIIAY",
       "Name": "Telecom Italia S.P.A. Ordinary Shares",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "TIIAY"
     },
     {
       "Cedears": "TIMB",
       "Name": "Tim Participações S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "TIMB"
     },
     {
       "Cedears": "TIMS3",
       "Name": "TIM S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "TIMS3"
     },
     {
       "Cedears": "TJX",
       "Name": "TJX Companies Inc/The",
       "Market": "NYSE",
-      "Ratio": "22"
+      "Ratio": "22",
+      "TickerOriginal": "TJX"
     },
     {
       "Cedears": "TM",
       "Name": "Toyota Motor Corporation",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "TM"
     },
     {
       "Cedears": "TMO",
       "Name": "Thermo Fisher Scientific Inc.",
       "Market": "NYSE",
-      "Ratio": "22"
+      "Ratio": "22",
+      "TickerOriginal": "TMO"
     },
     {
       "Cedears": "TMUS",
       "Name": "T-mobile",
       "Market": "NASDAQ",
-      "Ratio": "33"
+      "Ratio": "33",
+      "TickerOriginal": "TMUS"
     },
     {
       "Cedears": "TQQQ",
       "Name": "ProShares UltraPro QQQ",
       "Market": "NASDAQ",
-      "Ratio": "25"
+      "Ratio": "25",
+      "TickerOriginal": "TQQQ"
     },
     {
       "Cedears": "TRIP",
       "Name": "Tripadvisor, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "TRIP"
     },
     {
       "Cedears": "TRVV",
       "Name": "The Travelers Cos. Inc.",
       "Market": "NYSE",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "TRVV"
     },
     {
       "Cedears": "TSLA",
       "Name": "Tesla, Inc.",
       "Market": "NASDAQ",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "TSLA"
     },
     {
       "Cedears": "TSM",
       "Name": "Taiwan Semiconductor Manufacturing",
       "Market": "NYSE",
-      "Ratio": "9"
+      "Ratio": "9",
+      "TickerOriginal": "TSM"
     },
     {
       "Cedears": "TTE",
       "Name": "TotalEnergies SE",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "TTE"
     },
     {
       "Cedears": "TTM",
       "Name": "Tata Motors Ltd",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "TTM"
     },
     {
       "Cedears": "TV",
       "Name": "Grupo Televisa S.A.",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "TV"
     },
     {
       "Cedears": "TWLO",
       "Name": "Twilio Inc",
       "Market": "NYSE",
-      "Ratio": "36"
+      "Ratio": "36",
+      "TickerOriginal": "TWLO"
     },
     {
       "Cedears": "TWTR",
       "Name": "Twitter, Inc.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "TWTR"
     },
     {
       "Cedears": "TXN",
       "Name": "Texas Instruments Inc",
       "Market": "NASDAQ",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "TXN"
     },
     {
       "Cedears": "TXR",
       "Name": "Ternium S.A.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "TXR"
     },
     {
       "Cedears": "UAL",
       "Name": "United Airlines Holdings Inc.",
       "Market": "NASDAQ GS",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "UAL"
     },
     {
       "Cedears": "UBER",
       "Name": "Uber Technologies Inc.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "UBER"
     },
     {
       "Cedears": "UGP",
       "Name": "Ultrapar Participações S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "UGP"
     },
     {
       "Cedears": "UL",
       "Name": "Unilever PLC - Sponsored",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "UL"
     },
     {
       "Cedears": "UN",
       "Name": "NU Holdings Ltd/Cayman Islands",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "UN"
     },
     {
       "Cedears": "UNH",
       "Name": "UnitedHealth Group Inc.",
       "Market": "NYSE",
-      "Ratio": "33"
+      "Ratio": "33",
+      "TickerOriginal": "UNH"
     },
     {
       "Cedears": "UNP",
       "Name": "Union Pacific Corp.",
       "Market": "NYSE",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "UNP"
     },
     {
       "Cedears": "UPST",
       "Name": "Upstart Hldgs Inc",
       "Market": "NASDAQ GS",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "UPST"
     },
     {
       "Cedears": "URA",
       "Name": "Global X Uranium ETF",
       "Market": "NYSE Arca",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "URA"
     },
     {
       "Cedears": "URBN",
       "Name": "Urban Outfitters INC.",
       "Market": "NASDAQ",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "URBN"
     },
     {
       "Cedears": "USB",
       "Name": "U.S. Bancorp",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "USB"
     },
     {
       "Cedears": "USO",
       "Name": "United States Oil Fund",
       "Market": "NYSE",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "USO"
     },
     {
       "Cedears": "V",
       "Name": "Visa Inc",
       "Market": "NYSE",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "V"
     },
     {
       "Cedears": "VALE",
       "Name": "Vale S.A.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "VALE"
     },
     {
       "Cedears": "VALE3",
       "Name": "Vale S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "VALE3"
     },
     {
       "Cedears": "VEA",
       "Name": "Vanguard FTSE Developed Markets ETF",
       "Market": "NYSE Arca",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "VEA"
     },
     {
       "Cedears": "VIG",
       "Name": "VANGUARD DIVIDEND APPRECIATION",
       "Market": "NYSE Arca",
-      "Ratio": "39"
+      "Ratio": "39",
+      "TickerOriginal": "VIG"
     },
     {
       "Cedears": "VIST",
       "Name": "Vista Energy S.A.B. de C.V.",
       "Market": "NYSE",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "VIST"
     },
     {
       "Cedears": "VIV",
       "Name": "Telefônica Brasil S.A.",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "VIV"
     },
     {
       "Cedears": "VIVT3",
       "Name": "Telefônica Brasil S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "VIVT3"
     },
     {
       "Cedears": "VOD",
       "Name": "Vodafone Group Plc",
       "Market": "NASDAQ",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "VOD"
     },
     {
       "Cedears": "VRSN",
       "Name": "Verisign, Inc.",
       "Market": "-",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "VRSN"
     },
     {
       "Cedears": "VRTX",
       "Name": "VERTEX PHARMACEUTICALS INC",
       "Market": "NYSE",
-      "Ratio": "101"
+      "Ratio": "101",
+      "TickerOriginal": "VRTX"
     },
     {
       "Cedears": "VST",
       "Name": "VISTRA CORPORATION",
       "Market": "NYSE",
-      "Ratio": "26"
+      "Ratio": "26",
+      "TickerOriginal": "VST"
     },
     {
       "Cedears": "VXX",
       "Name": "iPath Series B S&P 500 VIX",
       "Market": "CBOE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "VXX"
     },
     {
       "Cedears": "VZ",
       "Name": "Verizon Communications Inc.",
       "Market": "NYSE",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "VZ"
     },
     {
       "Cedears": "WBA",
       "Name": "Walgreens Boots Alliance Inc.",
       "Market": "NASDAQ",
-      "Ratio": "3"
+      "Ratio": "3",
+      "TickerOriginal": "WBA"
     },
     {
       "Cedears": "WBO",
       "Name": "Weibo Corporation",
       "Market": "NASDAQ",
-      "Ratio": "6"
+      "Ratio": "6",
+      "TickerOriginal": "WBO"
     },
     {
       "Cedears": "WEGE3",
       "Name": "Weg S.A.",
       "Market": "B3",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "WEGE3"
     },
     {
       "Cedears": "WFC",
       "Name": "Wells Fargo & Co.",
       "Market": "NYSE",
-      "Ratio": "5"
+      "Ratio": "5",
+      "TickerOriginal": "WFC"
     },
     {
       "Cedears": "WMT",
       "Name": "Walmart Inc.",
       "Market": "NYSE",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "WMT"
     },
     {
       "Cedears": "XLB",
       "Name": "The Materials Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "18"
+      "Ratio": "18",
+      "TickerOriginal": "XLB"
     },
     {
       "Cedears": "XLC",
       "Name": "The Communication Services Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "19"
+      "Ratio": "19",
+      "TickerOriginal": "XLC"
     },
     {
       "Cedears": "XLE",
       "Name": "ENERGY SELECT SECTOR SPDR FUND",
       "Market": "NYSE Arca",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "XLE"
     },
     {
       "Cedears": "XLF",
       "Name": "FINANCIAL SELECT SECTOR SPDR FUND",
       "Market": "NYSE Arca",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "XLF"
     },
     {
       "Cedears": "XLI",
       "Name": "The Industrial Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "28"
+      "Ratio": "28",
+      "TickerOriginal": "XLI"
     },
     {
       "Cedears": "XLK",
       "Name": "The Technology Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "46"
+      "Ratio": "46",
+      "TickerOriginal": "XLK"
     },
     {
       "Cedears": "XLP",
       "Name": "The Consumer Staples Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "16"
+      "Ratio": "16",
+      "TickerOriginal": "XLP"
     },
     {
       "Cedears": "XLRE",
       "Name": "The Real Estate Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "9"
+      "Ratio": "9",
+      "TickerOriginal": "XLRE"
     },
     {
       "Cedears": "XLU",
       "Name": "Utilities Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "15"
+      "Ratio": "15",
+      "TickerOriginal": "XLU"
     },
     {
       "Cedears": "XLV",
       "Name": "The Health Care Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "29"
+      "Ratio": "29",
+      "TickerOriginal": "XLV"
     },
     {
       "Cedears": "XME",
       "Name": "State Street SPDR S&P Metals & Mining ETF",
       "Market": "NYSE ARCA",
-      "Ratio": "30"
+      "Ratio": "30",
+      "TickerOriginal": "XME"
     },
     {
       "Cedears": "XLY",
       "Name": "The Consumer Discretionary Select Sector SPDR Fund",
       "Market": "NYSE Arca",
-      "Ratio": "43"
+      "Ratio": "43",
+      "TickerOriginal": "XLY"
     },
     {
       "Cedears": "XOM",
       "Name": "Exxon Mobil Corporation",
       "Market": "NYSE",
-      "Ratio": "10"
+      "Ratio": "10",
+      "TickerOriginal": "XOM"
     },
     {
       "Cedears": "XP",
       "Name": "XP Inc",
       "Market": "NASDAQ",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "XP"
     },
     {
       "Cedears": "XPEV",
       "Name": "XPENG INC",
       "Market": "New York",
-      "Ratio": "4"
+      "Ratio": "4",
+      "TickerOriginal": "XPEV"
     },
     {
       "Cedears": "XROX",
       "Name": "Xerox Holding Corporation",
       "Market": "NYSE",
-      "Ratio": "1"
+      "Ratio": "1",
+      "TickerOriginal": "XROX"
     },
     {
       "Cedears": "XYZ",
       "Name": "Square Inc.",
       "Market": "NYSE",
-      "Ratio": "20"
+      "Ratio": "20",
+      "TickerOriginal": "XYZ"
     },
     {
       "Cedears": "YELP",
       "Name": "Yelp Inc.",
       "Market": "NYSE",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "YELP"
     },
     {
       "Cedears": "YZCA",
       "Name": "Yanzhou Coal Mining Co. Ltd.",
       "Market": "OTC US",
-      "Ratio": "2"
+      "Ratio": "2",
+      "TickerOriginal": "YZCA"
     },
     {
       "Cedears": "ZM",
       "Name": "Zoom Video Communications Inc.",
       "Market": "NASDAQ",
-      "Ratio": "47"
+      "Ratio": "47",
+      "TickerOriginal": "ZM"
     }
   ]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -545,11 +545,12 @@
     "Cedears": "Ticker del CEDEAR en BYMA",
     "Name": "Nombre de la empresa / instrumento subyacente",
     "Market": "Mercado del subyacente (ej. NYSE, NASDAQ, B3)",
-    "Ratio": "String de conversión…"
+    "Ratio": "String de conversión…",
+    "TickerOriginal": "Ticker del subyacente en su mercado de origen"
   },
   "items": [
-    { "Cedears": "AAPL", "Name": "Apple Inc.", "Market": "NASDAQ", "Ratio": "20" },
-    { "Cedears": "ABEV", "Name": "Ambev S.A.", "Market": "NASDAQ", "Ratio": "1:3" }
+    { "Cedears": "AAPL", "Name": "Apple Inc.", "Market": "NASDAQ", "Ratio": "20", "TickerOriginal": "AAPL" },
+    { "Cedears": "ADGO", "Name": "Adecoagro S.A.", "Market": "NYSE", "Ratio": "1", "TickerOriginal": "AGRO" }
   ]
 }</pre>
         </div>

--- a/src/cedear.js
+++ b/src/cedear.js
@@ -6,7 +6,8 @@
  *                      'q_bid' (cantidad bid), 'px_bid' (precio bid), 'px_ask' (precio ask),
  *                      'q_ask' (cantidad ask), 'q_op' (operaciones diarias), 'pct_change' (variación porcentual),
  *                      'name' (nombre completo), 'ratio' (ratio de conversión),
- *                      'market' (mercado donde cotiza el subyacente)
+ *                      'market' (mercado donde cotiza el subyacente),
+ *                      'ticker_original' (ticker del subyacente en su mercado de origen)
  * @return El valor del atributo solicitado para el símbolo especificado.
  * @customfunction
  */
@@ -15,13 +16,13 @@ function CEDEAR(symbol, value) {
     throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
   }
   if (value === undefined || value === null || value === '') {
-    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market.");
+    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market, ticker_original.");
   }
 
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
 
-  var atributosPermitidosJson = ['name', 'ratio', 'market'];
+  var atributosPermitidosJson = ['name', 'ratio', 'market', 'ticker_original'];
 
   if (atributosPermitidosJson.includes(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
@@ -40,7 +41,7 @@ function CEDEAR(symbol, value) {
  * Obtiene datos de CEDEARs desde el archivo JSON local.
  *
  * @param {string} symbol El símbolo del CEDEAR
- * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio' o 'market')
+ * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio', 'market' o 'ticker_original')
  * @return El valor del atributo solicitado
  */
 function buscarCedearEnJson(cedears, symbol, attribute) {
@@ -53,6 +54,8 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
         return cedears[i].Ratio;
       } else if (attribute === 'market') {
         return cedears[i].Market;
+      } else if (attribute === 'ticker_original') {
+        return cedears[i].TickerOriginal;
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates the enriched CEDEAR metadata (`cedears_enriched.json`) into `data/cedears.json`, adding the **`TickerOriginal`** field for all 428 entries.

`TickerOriginal` is the ticker of the underlying instrument in its home market. In most cases it matches the BYMA CEDEAR ticker; three entries differ:

| CEDEAR (BYMA) | TickerOriginal |
|---------------|----------------|
| ADGO | AGRO |
| AOCA | ACH |
| BA.C | BAC |

## Changes

- **`data/cedears.json`**: add `TickerOriginal` to every entry
- **`docs/api/cedears.json`**: regenerated via `npm run build` with updated schema metadata
- **`build.js`**: document `TickerOriginal` in the static API `fields` map
- **`src/cedear.js`**: expose `=CEDEAR(symbol; "ticker_original")`
- **Docs**: `doc/CEDEAR.md`, `docs/README.md`, `docs/index.html`

## Usage

```
=CEDEAR("ADGO"; "ticker_original")  → AGRO
=CEDEAR("AAPL"; "ticker_original") → AAPL
```

## Test plan

- [x] `npm run build`
- [x] `npm test` (47 tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e8a661d-a3b5-4857-8866-1b547dc4cf9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e8a661d-a3b5-4857-8866-1b547dc4cf9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

