### PR TITLE
Expose yfinance-metadata fields via CEDEAR()

### DIFF
--- a/all-in-one.js
+++ b/all-in-one.js
@@ -10,6 +10,8 @@ CONSTANTS.GASTOS_GARANTIA_TASA_DIARIA = 0.045 / 100 / 90;
 CONSTANTS.IVA_PORCENTAJE = 21 / 100;
 CONSTANTS.ARANCEL_CAUCION_COLOCADORA_TNA = 1.5 / 100;
 CONSTANTS.ARANCEL_CAUCION_TOMADORA_TNA = 4.0 / 100;
+CONSTANTS.ATRIBUTOS_JSON_CEDEAR = ['name', 'ratio', 'market', 'ticker_original'];
+CONSTANTS.ATRIBUTOS_YFINANCE_METADATA = ['yahoo_symbol', 'fetched_at', 'long_description', 'city', 'state', 'country', 'zip', 'address', 'sector', 'industry', 'website', 'phone', 'employees', 'long_name', 'short_name', 'exchange', 'quote_type', 'currency', 'logo_url', 'error'];
 CONSTANTS.HTTP_CACHE_MAX_CHARS = 90000;
 CONSTANTS.HTTP_DEFAULT_TTL = 120;
 CONSTANTS.ATRIBUTOS_HISTORICO = ['o', 'h', 'l', 'c', 'v', 'dr', 'sa'];
@@ -486,7 +488,8 @@ function CALCULARCAUCION(
  *                      'q_ask' (cantidad ask), 'q_op' (operaciones diarias), 'pct_change' (variación porcentual),
  *                      'name' (nombre completo), 'ratio' (ratio de conversión),
  *                      'market' (mercado donde cotiza el subyacente),
- *                      'ticker_original' (ticker del subyacente en su mercado de origen)
+ *                      'ticker_original' (ticker del subyacente en su mercado de origen),
+ *                      o campos de yfinance-metadata (sector, industry, website, long_description, etc.)
  * @return El valor del atributo solicitado para el símbolo especificado.
  * @customfunction
  */
@@ -495,15 +498,13 @@ function CEDEAR(symbol, value) {
     throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
   }
   if (value === undefined || value === null || value === '') {
-    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market, ticker_original.");
+    throw new Error('Atributo no proporcionado. Atributos disponibles: ' + mensajeAtributosCedear() + '.');
   }
 
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
 
-  var atributosPermitidosJson = ['name', 'ratio', 'market', 'ticker_original'];
-
-  if (atributosPermitidosJson.includes(atributo)) {
+  if (esAtributoDesdeJsonCedear(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
   }
 
@@ -516,11 +517,28 @@ function CEDEAR(symbol, value) {
   );
 }
 
+// Constante CONSTANTS.ATRIBUTOS_JSON_CEDEAR movida al namespace CONSTANTS
+// var ATRIBUTOS_JSON_CEDEAR = ['name', 'ratio', 'market', 'ticker_original'];
+// Constante CONSTANTS.ATRIBUTOS_YFINANCE_METADATA movida al namespace CONSTANTS
+// var ATRIBUTOS_YFINANCE_METADATA = ['yahoo_symbol', 'fetched_at', 'long_description', 'city', 'state', 'country', 'zip', 'address', 'sector', 'industry', 'website', 'phone', 'employees', 'long_name', 'short_name', 'exchange', 'quote_type', 'currency', 'logo_url', 'error'];
+
+function esAtributoDesdeJsonCedear(atributo) {
+  return CONSTANTS.ATRIBUTOS_JSON_CEDEAR.indexOf(atributo) !== -1 ||
+    CONSTANTS.ATRIBUTOS_YFINANCE_METADATA.indexOf(atributo) !== -1;
+}
+
+function mensajeAtributosCedear() {
+  return (
+    'c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market, ticker_original, ' +
+    CONSTANTS.ATRIBUTOS_YFINANCE_METADATA.join(', ')
+  );
+}
+
 /**
  * Obtiene datos de CEDEARs desde el archivo JSON local.
  *
  * @param {string} symbol El símbolo del CEDEAR
- * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio', 'market' o 'ticker_original')
+ * @param {string} attribute El atributo que se quiere obtener
  * @return El valor del atributo solicitado
  */
 function buscarCedearEnJson(cedears, symbol, attribute) {
@@ -535,10 +553,23 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
         return cedears[i].Market;
       } else if (attribute === 'ticker_original') {
         return cedears[i].TickerOriginal;
+      } else if (CONSTANTS.ATRIBUTOS_YFINANCE_METADATA.indexOf(attribute) !== -1) {
+        return obtenerCedearMetadataYfinance(cedears[i], symbol, attribute);
       }
     }
   }
   throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en el archivo de CEDEARs.");
+}
+
+function obtenerCedearMetadataYfinance(item, symbol, attribute) {
+  var metadata = item['yfinance-metadata'];
+  if (!metadata) {
+    throw new Error("Metadata yfinance no disponible para '" + symbol + "'.");
+  }
+  if (metadata[attribute] === undefined || metadata[attribute] === null) {
+    return '';
+  }
+  return metadata[attribute];
 }
 
 function cargarCedearsDesdeDrive() {

--- a/doc/CEDEAR.md
+++ b/doc/CEDEAR.md
@@ -88,6 +88,7 @@ En cualquier celda de la hoja, escribe:
 - "ratio" - Ratio de conversión entre el CEDEAR y la acción subyacente
 - "market" - Mercado donde cotiza el subyacente (ej. NYSE, NASDAQ, B3)
 - "ticker_original" - Ticker del subyacente en su mercado de origen (ej. ADGO → AGRO)
+- Campos de **yfinance-metadata** (desde `data/cedears.json`): `sector`, `industry`, `website`, `long_description`, `city`, `state`, `country`, `employees`, `logo_url`, `yahoo_symbol`, `error`, etc. (ver tabla arriba)
 
 ## Ejemplos
 
@@ -100,6 +101,9 @@ En cualquier celda de la hoja, escribe:
 | `=CEDEAR("AMZN"; "ratio")` | Ratio de conversión del CEDEAR de Amazon |
 | `=CEDEAR("AAPL"; "market")` | Mercado donde cotiza Apple (NASDAQ) |
 | `=CEDEAR("ADGO"; "ticker_original")` | Ticker del subyacente Adecoagro (AGRO) |
+| `=CEDEAR("AAPL"; "sector")` | Sector del subyacente (Technology) |
+| `=CEDEAR("AAPL"; "website")` | Sitio web de la empresa |
+| `=CEDEAR("AAPL"; "long_description")` | Descripción del negocio desde Yahoo Finance |
 
 ## Función CedearLista
 
@@ -123,7 +127,10 @@ Esta función devuelve una tabla con todos los CEDEARs disponibles y sus datos a
 "Símbolo inválido: 'xyz'. No se encontró en la lista de CEDEARs disponibles."
 
 **Atributo inválido**  
-"Atributo inválido: 'xyz'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market."
+"Atributo inválido: 'xyz'. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market, ticker_original, sector, industry, website, ..."
+
+**Metadata yfinance no disponible**  
+"Metadata yfinance no disponible para 'XYZ'." (el CEDEAR existe pero no tiene bloque `yfinance-metadata` en el JSON)
 
 ## Ver también
 

--- a/src/cedear.js
+++ b/src/cedear.js
@@ -7,7 +7,8 @@
  *                      'q_ask' (cantidad ask), 'q_op' (operaciones diarias), 'pct_change' (variación porcentual),
  *                      'name' (nombre completo), 'ratio' (ratio de conversión),
  *                      'market' (mercado donde cotiza el subyacente),
- *                      'ticker_original' (ticker del subyacente en su mercado de origen)
+ *                      'ticker_original' (ticker del subyacente en su mercado de origen),
+ *                      o campos de yfinance-metadata (sector, industry, website, long_description, etc.)
  * @return El valor del atributo solicitado para el símbolo especificado.
  * @customfunction
  */
@@ -16,15 +17,13 @@ function CEDEAR(symbol, value) {
     throw new Error("Símbolo no proporcionado. Debe ingresar un símbolo válido (ej: 'AAPL').");
   }
   if (value === undefined || value === null || value === '') {
-    throw new Error("Atributo no proporcionado. Atributos disponibles: c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market, ticker_original.");
+    throw new Error('Atributo no proporcionado. Atributos disponibles: ' + mensajeAtributosCedear() + '.');
   }
 
   var simbolo = symbol.toString().toUpperCase().trim();
   var atributo = value.toString().toLowerCase().trim();
 
-  var atributosPermitidosJson = ['name', 'ratio', 'market', 'ticker_original'];
-
-  if (atributosPermitidosJson.includes(atributo)) {
+  if (esAtributoDesdeJsonCedear(atributo)) {
     return getCedearDataFromJson(simbolo, atributo);
   }
 
@@ -37,11 +36,26 @@ function CEDEAR(symbol, value) {
   );
 }
 
+var ATRIBUTOS_JSON_CEDEAR = ['name', 'ratio', 'market', 'ticker_original'];
+var ATRIBUTOS_YFINANCE_METADATA = ['yahoo_symbol', 'fetched_at', 'long_description', 'city', 'state', 'country', 'zip', 'address', 'sector', 'industry', 'website', 'phone', 'employees', 'long_name', 'short_name', 'exchange', 'quote_type', 'currency', 'logo_url', 'error'];
+
+function esAtributoDesdeJsonCedear(atributo) {
+  return ATRIBUTOS_JSON_CEDEAR.indexOf(atributo) !== -1 ||
+    ATRIBUTOS_YFINANCE_METADATA.indexOf(atributo) !== -1;
+}
+
+function mensajeAtributosCedear() {
+  return (
+    'c, v, q_bid, px_bid, px_ask, q_ask, q_op, pct_change, name, ratio, market, ticker_original, ' +
+    ATRIBUTOS_YFINANCE_METADATA.join(', ')
+  );
+}
+
 /**
  * Obtiene datos de CEDEARs desde el archivo JSON local.
  *
  * @param {string} symbol El símbolo del CEDEAR
- * @param {string} attribute El atributo que se quiere obtener ('name', 'ratio', 'market' o 'ticker_original')
+ * @param {string} attribute El atributo que se quiere obtener
  * @return El valor del atributo solicitado
  */
 function buscarCedearEnJson(cedears, symbol, attribute) {
@@ -56,10 +70,23 @@ function buscarCedearEnJson(cedears, symbol, attribute) {
         return cedears[i].Market;
       } else if (attribute === 'ticker_original') {
         return cedears[i].TickerOriginal;
+      } else if (ATRIBUTOS_YFINANCE_METADATA.indexOf(attribute) !== -1) {
+        return obtenerCedearMetadataYfinance(cedears[i], symbol, attribute);
       }
     }
   }
   throw new Error("Símbolo inválido: '" + symbol + "'. No se encontró en el archivo de CEDEARs.");
+}
+
+function obtenerCedearMetadataYfinance(item, symbol, attribute) {
+  var metadata = item['yfinance-metadata'];
+  if (!metadata) {
+    throw new Error("Metadata yfinance no disponible para '" + symbol + "'.");
+  }
+  if (metadata[attribute] === undefined || metadata[attribute] === null) {
+    return '';
+  }
+  return metadata[attribute];
 }
 
 function cargarCedearsDesdeDrive() {

--- a/tests/cedear.test.js
+++ b/tests/cedear.test.js
@@ -1,0 +1,102 @@
+function createResponse(statusCode, body) {
+  return {
+    getResponseCode: () => statusCode,
+    getContentText: () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+const CEDEARS_FIXTURE = [
+  {
+    Cedears: 'AAPL',
+    Name: 'Apple Inc.',
+    Market: 'NASDAQ',
+    Ratio: '20',
+    TickerOriginal: 'AAPL',
+    'yfinance-metadata': {
+      yahoo_symbol: 'AAPL',
+      fetched_at: '2026-07-21T10:00:00Z',
+      sector: 'Technology',
+      industry: 'Consumer Electronics',
+      website: 'https://www.apple.com',
+      city: 'Cupertino',
+      employees: 164000,
+    },
+  },
+  {
+    Cedears: 'WBA',
+    Name: 'Walgreens Boots Alliance Inc',
+    Market: 'NASDAQ',
+    Ratio: '9',
+    TickerOriginal: 'WBA',
+    'yfinance-metadata': {
+      yahoo_symbol: 'WBA',
+      fetched_at: '2026-07-21T10:00:00Z',
+      error: 'no_data',
+    },
+  },
+  {
+    Cedears: 'XYZ',
+    Name: 'Legacy Corp',
+    Market: 'NYSE',
+    Ratio: '1',
+    TickerOriginal: 'XYZ',
+  },
+];
+
+describe('CEDEAR metadata yfinance', () => {
+  let CEDEAR;
+  let fetchMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    fetchMock = jest.fn();
+
+    global.UrlFetchApp = { fetch: fetchMock };
+    global.Utilities = {};
+    global.DriveApp = {
+      getFilesByName: () => ({
+        hasNext: () => false,
+      }),
+    };
+    global.Logger = { log: jest.fn() };
+    global.CacheService = {
+      getScriptCache: () => ({
+        get: () => null,
+        put: () => {},
+      }),
+    };
+
+    fetchMock.mockReturnValue(createResponse(200, CEDEARS_FIXTURE));
+    ({ CEDEAR } = require('./test-wrapper'));
+  });
+
+  afterEach(() => {
+    delete global.UrlFetchApp;
+    delete global.Utilities;
+    delete global.DriveApp;
+    delete global.Logger;
+    delete global.CacheService;
+  });
+
+  test('sector devuelve metadata yfinance del JSON', () => {
+    expect(CEDEAR('AAPL', 'sector')).toBe('Technology');
+  });
+
+  test('website e industry devuelven metadata yfinance', () => {
+    expect(CEDEAR('AAPL', 'website')).toBe('https://www.apple.com');
+    expect(CEDEAR('AAPL', 'industry')).toBe('Consumer Electronics');
+  });
+
+  test('campo ausente en metadata devuelve string vacío', () => {
+    expect(CEDEAR('AAPL', 'long_description')).toBe('');
+  });
+
+  test('error de yfinance se puede consultar explícitamente', () => {
+    expect(CEDEAR('WBA', 'error')).toBe('no_data');
+    expect(CEDEAR('WBA', 'sector')).toBe('');
+  });
+
+  test('sin bloque yfinance-metadata lanza error claro', () => {
+    expect(() => CEDEAR('XYZ', 'sector')).toThrow("Metadata yfinance no disponible para 'XYZ'");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends `=CEDEAR()` to read `yfinance-metadata` fields from `data/cedears.json`.

## New attributes

Examples:
- `=CEDEAR("AAPL"; "sector")`
- `=CEDEAR("AAPL"; "industry")`
- `=CEDEAR("AAPL"; "website")`
- `=CEDEAR("AAPL"; "long_description")`
- `=CEDEAR("AAPL"; "city")`
- `=CEDEAR("AAPL"; "employees")`

Full list: `yahoo_symbol`, `fetched_at`, `long_description`, `city`, `state`, `country`, `zip`, `address`, `sector`, `industry`, `website`, `phone`, `employees`, `long_name`, `short_name`, `exchange`, `quote_type`, `currency`, `logo_url`, `error`.

## Behavior

- Missing field in metadata → empty string
- Missing `yfinance-metadata` block → clear error
- Live panel attributes (`c`, `v`, etc.) unchanged

## Test plan

- [x] `npm run build`
- [x] `npm test` (52 tests, including 5 new CEDEAR metadata tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67916a96-12ea-49ec-9637-4a3c503dcfb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67916a96-12ea-49ec-9637-4a3c503dcfb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

