### PR TITLE
Add ETF category tags to CEDEAR metadata

### DIFF
--- a/data/cedears.json
+++ b/data/cedears.json
@@ -298,7 +298,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "ADBE",
@@ -895,7 +897,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "ARM",
@@ -2284,7 +2288,9 @@
     },
     "tags": [
       "Tech",
-      "Ciberseguridad"
+      "Ciberseguridad",
+      "Tecnología",
+      "ETFs"
     ]
   },
   {
@@ -2424,7 +2430,10 @@
       "currency": "USD"
     },
     "tags": [
-      "Minería & Metales"
+      "Minería & Metales",
+      "Materiales",
+      "Minería y metales",
+      "ETFs"
     ]
   },
   {
@@ -2900,7 +2909,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "DISN",
@@ -3136,7 +3148,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Mercados emergentes",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "EFA",
@@ -3155,7 +3170,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Mercados desarrollados",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "EFX",
@@ -3315,7 +3333,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "ETHA",
@@ -3334,7 +3355,9 @@
       "currency": "USD"
     },
     "tags": [
-      "Cripto & Bitcoin"
+      "Cripto & Bitcoin",
+      "Cripto",
+      "ETFs"
     ]
   },
   {
@@ -3382,7 +3405,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Países y regiones",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "EWY",
@@ -3399,7 +3425,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Países y regiones",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "EWZ",
@@ -3417,7 +3446,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Países y regiones",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "F",
@@ -3656,7 +3688,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Países y regiones",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "GDX",
@@ -3675,7 +3710,10 @@
       "currency": "USD"
     },
     "tags": [
-      "Oro & Plata"
+      "Oro & Plata",
+      "Materiales",
+      "Minería y metales",
+      "ETFs"
     ]
   },
   {
@@ -3811,7 +3849,9 @@
       "currency": "USD"
     },
     "tags": [
-      "Oro & Plata"
+      "Oro & Plata",
+      "Commodities",
+      "ETFs"
     ]
   },
   {
@@ -4627,7 +4667,8 @@
     },
     "tags": [
       "Salud",
-      "Farma & Biotecnología"
+      "Farma & Biotecnología",
+      "ETFs"
     ]
   },
   {
@@ -4647,7 +4688,9 @@
       "currency": "USD"
     },
     "tags": [
-      "Cripto & Bitcoin"
+      "Cripto & Bitcoin",
+      "Cripto",
+      "ETFs"
     ]
   },
   {
@@ -4727,7 +4770,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Energía limpia"
+      "Energía limpia",
+      "ETFs"
     ]
   },
   {
@@ -4746,7 +4790,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Mercados emergentes",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "IEUR",
@@ -4765,7 +4812,11 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Mercados desarrollados",
+      "Países y regiones",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "IFF",
@@ -4811,7 +4862,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "ILF",
@@ -4830,7 +4884,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Países y regiones",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "INFY",
@@ -5026,7 +5083,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Aeroespacial & Defensa"
+      "Aeroespacial & Defensa",
+      "ETFs"
     ]
   },
   {
@@ -5103,7 +5161,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "IVV",
@@ -5122,7 +5183,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "IVW",
@@ -5140,7 +5204,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "IWM",
@@ -5159,7 +5226,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "JCI",
@@ -7875,7 +7945,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "PSX",
@@ -8000,7 +8072,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "RACE",
@@ -8295,7 +8370,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "RTX",
@@ -8627,7 +8705,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "SHEL",
@@ -8824,7 +8904,9 @@
       "currency": "USD"
     },
     "tags": [
-      "Oro & Plata"
+      "Oro & Plata",
+      "Commodities",
+      "ETFs"
     ]
   },
   {
@@ -8845,7 +8927,9 @@
     },
     "tags": [
       "Tech",
-      "Semiconductores"
+      "Semiconductores",
+      "Tecnología",
+      "ETFs"
     ]
   },
   {
@@ -9143,7 +9227,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "SPOT",
@@ -9190,7 +9277,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Apalancados",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "SPY",
@@ -9208,7 +9298,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "STLA",
@@ -9789,7 +9882,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Apalancados",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "TRIP",
@@ -10197,7 +10293,9 @@
       "currency": "USD"
     },
     "tags": [
-      "Fintech & Pagos"
+      "Fintech & Pagos",
+      "Apalancados",
+      "ETFs"
     ]
   },
   {
@@ -10307,7 +10405,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Nuclear & Uranio"
+      "Nuclear & Uranio",
+      "ETFs"
     ]
   },
   {
@@ -10385,7 +10484,9 @@
       "currency": "USD"
     },
     "tags": [
-      "Petróleo & Gas"
+      "Petróleo & Gas",
+      "Commodities",
+      "ETFs"
     ]
   },
   {
@@ -10493,7 +10594,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Mercados desarrollados",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "VIG",
@@ -10512,7 +10616,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Índices de Estados Unidos",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "VIST",
@@ -10739,7 +10846,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "VZ",
@@ -10908,7 +11017,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Materiales",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "XLC",
@@ -10927,7 +11039,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Medios & Streaming"
+      "Medios & Streaming",
+      "ETFs"
     ]
   },
   {
@@ -10947,7 +11060,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Petróleo & Gas"
+      "Petróleo & Gas",
+      "ETFs"
     ]
   },
   {
@@ -10966,7 +11080,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "XLI",
@@ -10985,7 +11101,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Industriales"
+      "Industriales",
+      "ETFs"
     ]
   },
   {
@@ -11003,7 +11120,10 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "Tecnología",
+      "ETFs"
+    ]
   },
   {
     "Cedears": "XLP",
@@ -11022,7 +11142,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Consumo básico"
+      "Consumo básico",
+      "ETFs"
     ]
   },
   {
@@ -11041,7 +11162,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "XLU",
@@ -11059,7 +11182,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "XLV",
@@ -11077,7 +11202,8 @@
       "currency": "USD"
     },
     "tags": [
-      "Salud"
+      "Salud",
+      "ETFs"
     ]
   },
   {
@@ -11096,7 +11222,10 @@
       "currency": "USD"
     },
     "tags": [
-      "Minería & Metales"
+      "Minería & Metales",
+      "Materiales",
+      "Minería y metales",
+      "ETFs"
     ]
   },
   {
@@ -11114,7 +11243,9 @@
       "quote_type": "ETF",
       "currency": "USD"
     },
-    "tags": []
+    "tags": [
+      "ETFs"
+    ]
   },
   {
     "Cedears": "XOM",

--- a/docs/api/cedears.json
+++ b/docs/api/cedears.json
@@ -316,7 +316,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "ADBE",
@@ -913,7 +915,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "ARM",
@@ -2302,7 +2306,9 @@
       },
       "tags": [
         "Tech",
-        "Ciberseguridad"
+        "Ciberseguridad",
+        "Tecnología",
+        "ETFs"
       ]
     },
     {
@@ -2442,7 +2448,10 @@
         "currency": "USD"
       },
       "tags": [
-        "Minería & Metales"
+        "Minería & Metales",
+        "Materiales",
+        "Minería y metales",
+        "ETFs"
       ]
     },
     {
@@ -2918,7 +2927,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "DISN",
@@ -3154,7 +3166,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Mercados emergentes",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "EFA",
@@ -3173,7 +3188,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Mercados desarrollados",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "EFX",
@@ -3333,7 +3351,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "ETHA",
@@ -3352,7 +3373,9 @@
         "currency": "USD"
       },
       "tags": [
-        "Cripto & Bitcoin"
+        "Cripto & Bitcoin",
+        "Cripto",
+        "ETFs"
       ]
     },
     {
@@ -3400,7 +3423,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Países y regiones",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "EWY",
@@ -3417,7 +3443,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Países y regiones",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "EWZ",
@@ -3435,7 +3464,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Países y regiones",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "F",
@@ -3674,7 +3706,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Países y regiones",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "GDX",
@@ -3693,7 +3728,10 @@
         "currency": "USD"
       },
       "tags": [
-        "Oro & Plata"
+        "Oro & Plata",
+        "Materiales",
+        "Minería y metales",
+        "ETFs"
       ]
     },
     {
@@ -3829,7 +3867,9 @@
         "currency": "USD"
       },
       "tags": [
-        "Oro & Plata"
+        "Oro & Plata",
+        "Commodities",
+        "ETFs"
       ]
     },
     {
@@ -4645,7 +4685,8 @@
       },
       "tags": [
         "Salud",
-        "Farma & Biotecnología"
+        "Farma & Biotecnología",
+        "ETFs"
       ]
     },
     {
@@ -4665,7 +4706,9 @@
         "currency": "USD"
       },
       "tags": [
-        "Cripto & Bitcoin"
+        "Cripto & Bitcoin",
+        "Cripto",
+        "ETFs"
       ]
     },
     {
@@ -4745,7 +4788,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Energía limpia"
+        "Energía limpia",
+        "ETFs"
       ]
     },
     {
@@ -4764,7 +4808,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Mercados emergentes",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "IEUR",
@@ -4783,7 +4830,11 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Mercados desarrollados",
+        "Países y regiones",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "IFF",
@@ -4829,7 +4880,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "ILF",
@@ -4848,7 +4902,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Países y regiones",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "INFY",
@@ -5044,7 +5101,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Aeroespacial & Defensa"
+        "Aeroespacial & Defensa",
+        "ETFs"
       ]
     },
     {
@@ -5121,7 +5179,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "IVV",
@@ -5140,7 +5201,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "IVW",
@@ -5158,7 +5222,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "IWM",
@@ -5177,7 +5244,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "JCI",
@@ -7893,7 +7963,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "PSX",
@@ -8018,7 +8090,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "RACE",
@@ -8313,7 +8388,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "RTX",
@@ -8645,7 +8723,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "SHEL",
@@ -8842,7 +8922,9 @@
         "currency": "USD"
       },
       "tags": [
-        "Oro & Plata"
+        "Oro & Plata",
+        "Commodities",
+        "ETFs"
       ]
     },
     {
@@ -8863,7 +8945,9 @@
       },
       "tags": [
         "Tech",
-        "Semiconductores"
+        "Semiconductores",
+        "Tecnología",
+        "ETFs"
       ]
     },
     {
@@ -9161,7 +9245,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "SPOT",
@@ -9208,7 +9295,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Apalancados",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "SPY",
@@ -9226,7 +9316,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "STLA",
@@ -9807,7 +9900,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Apalancados",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "TRIP",
@@ -10215,7 +10311,9 @@
         "currency": "USD"
       },
       "tags": [
-        "Fintech & Pagos"
+        "Fintech & Pagos",
+        "Apalancados",
+        "ETFs"
       ]
     },
     {
@@ -10325,7 +10423,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Nuclear & Uranio"
+        "Nuclear & Uranio",
+        "ETFs"
       ]
     },
     {
@@ -10403,7 +10502,9 @@
         "currency": "USD"
       },
       "tags": [
-        "Petróleo & Gas"
+        "Petróleo & Gas",
+        "Commodities",
+        "ETFs"
       ]
     },
     {
@@ -10511,7 +10612,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Mercados desarrollados",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "VIG",
@@ -10530,7 +10634,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Índices de Estados Unidos",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "VIST",
@@ -10757,7 +10864,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "VZ",
@@ -10926,7 +11035,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Materiales",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "XLC",
@@ -10945,7 +11057,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Medios & Streaming"
+        "Medios & Streaming",
+        "ETFs"
       ]
     },
     {
@@ -10965,7 +11078,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Petróleo & Gas"
+        "Petróleo & Gas",
+        "ETFs"
       ]
     },
     {
@@ -10984,7 +11098,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "XLI",
@@ -11003,7 +11119,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Industriales"
+        "Industriales",
+        "ETFs"
       ]
     },
     {
@@ -11021,7 +11138,10 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "Tecnología",
+        "ETFs"
+      ]
     },
     {
       "Cedears": "XLP",
@@ -11040,7 +11160,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Consumo básico"
+        "Consumo básico",
+        "ETFs"
       ]
     },
     {
@@ -11059,7 +11180,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "XLU",
@@ -11077,7 +11200,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "XLV",
@@ -11095,7 +11220,8 @@
         "currency": "USD"
       },
       "tags": [
-        "Salud"
+        "Salud",
+        "ETFs"
       ]
     },
     {
@@ -11114,7 +11240,10 @@
         "currency": "USD"
       },
       "tags": [
-        "Minería & Metales"
+        "Minería & Metales",
+        "Materiales",
+        "Minería y metales",
+        "ETFs"
       ]
     },
     {
@@ -11132,7 +11261,9 @@
         "quote_type": "ETF",
         "currency": "USD"
       },
-      "tags": []
+      "tags": [
+        "ETFs"
+      ]
     },
     {
       "Cedears": "XOM",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds new thematic tags to 55 ETF CEDEARs in `data/cedears.json`, merged with existing tags.

## New tags

| Tag | Tickers |
|-----|---------|
| Apalancados | SPXL, TQQQ, UN |
| Cripto | ETHA, IBIT |
| Commodities | GLD, SLV, USO |
| Materiales | COPX, GDX, XLB, XME |
| Minería y metales | COPX, GDX, XME |
| Tecnología | CIBR, SMH, XLK |
| Mercados desarrollados | EFA, IEUR, VEA |
| Mercados emergentes | EEM, IEMG |
| Países y regiones | EWJ, EWY, EWZ, FXI, IEUR, ILF |
| Índices de Estados Unidos | DIA, ESGU, IJH, IVE, IVV, IVW, IWM, QQQ, RSP, SPHQ, SPY, VIG |
| ETFs | todos los tickers de `todos_los_etfs` (55 en total) |

Tags are appended without duplicating existing ones (e.g. COPX keeps `Minería & Metales` and gains `Materiales`, `Minería y metales`, `ETFs`).

## Test plan

- [x] `npm run build`
- [x] `npm test` — 52 tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6537365-73d2-4503-aa20-c7f5814ddd95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6537365-73d2-4503-aa20-c7f5814ddd95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

